### PR TITLE
feat: add configuration space for dropdown options

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -52,6 +52,9 @@
                 <button class="tab" onclick="switchTab('history')">
                     📜 Historique
                 </button>
+                <button class="tab" onclick="switchTab('config')">
+                    ⚙️ Configuration
+                </button>
             </div>
         </div>
 
@@ -202,31 +205,18 @@
                         <label class="filter-label">Processus</label>
                         <select class="filter-select" id="processFilter" onchange="applyFilters()">
                             <option value="">Tous les processus</option>
-                            <option value="rd">R&D et développement clinique</option>
-                            <option value="achats">Achats et approvisionnements</option>
-                            <option value="marketing">Marketing et communication</option>
-                            <option value="ventes">Ventes et relations clients</option>
-                            <option value="rh">Ressources humaines</option>
                         </select>
                     </div>
                     <div class="filter-group">
                         <label class="filter-label">Type de Risque</label>
                         <select class="filter-select" id="riskTypeFilter" onchange="applyFilters()">
                             <option value="">Tous les types</option>
-                            <option value="corruption-active">Corruption active</option>
-                            <option value="corruption-passive">Corruption passive</option>
-                            <option value="trafic-influence">Trafic d'influence</option>
-                            <option value="favoritisme">Favoritisme</option>
                         </select>
                     </div>
                     <div class="filter-group">
                         <label class="filter-label">Statut</label>
                         <select class="filter-select" id="statusFilter" onchange="applyFilters()">
                             <option value="">Tous les statuts</option>
-                            <option value="nouveau">Nouveau</option>
-                            <option value="en-cours">En cours de traitement</option>
-                            <option value="traite">Traité</option>
-                            <option value="archive">Archivé</option>
                         </select>
                     </div>
                     <div class="search-box filter-group">
@@ -433,6 +423,14 @@
                 </div>
             </div>
         </div>
+        <div id="config-tab" class="tab-content">
+            <div class="main-content">
+                <div class="toolbar">
+                    <div class="toolbar-title">Configuration</div>
+                </div>
+                <div class="content-area" id="configurationContainer"></div>
+            </div>
+        </div>
     </div>
 
     <!-- Control Form Modal -->
@@ -469,8 +467,6 @@
                                 <label for="controlType">Type de contrôle *</label>
                                 <select id="controlType" name="type" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="preventif">Préventif</option>
-                                    <option value="detectif">Détectif</option>
                                 </select>
                             </div>
 
@@ -483,10 +479,6 @@
                                 <label for="controlFrequency">Fréquence *</label>
                                 <select id="controlFrequency" name="frequency" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="quotidienne">Quotidienne</option>
-                                    <option value="mensuelle">Mensuelle</option>
-                                    <option value="annuelle">Annuelle</option>
-                                    <option value="ad-hoc">Ad hoc</option>
                                 </select>
                             </div>
 
@@ -494,8 +486,6 @@
                                 <label for="controlMode">Mode d'exécution *</label>
                                 <select id="controlMode" name="mode" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="manuel">Manuel</option>
-                                    <option value="automatise">Automatisé</option>
                                 </select>
                             </div>
 
@@ -503,9 +493,6 @@
                                 <label for="controlEffectiveness">Efficacité estimée *</label>
                                 <select id="controlEffectiveness" name="effectiveness" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="forte">Forte</option>
-                                    <option value="moyenne">Moyenne</option>
-                                    <option value="faible">Faible</option>
                                 </select>
                             </div>
 
@@ -513,10 +500,6 @@
                                 <label for="controlStatus">Statut *</label>
                                 <select id="controlStatus" name="status" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="actif">Actif</option>
-                                    <option value="en-mise-en-place">En mise en place</option>
-                                    <option value="en-revision">En cours de révision</option>
-                                    <option value="obsolete">Obsolète</option>
                                 </select>
                             </div>
                         </div>
@@ -578,22 +561,12 @@
                                 <label class="form-label required">Processus</label>
                                 <select class="form-select" id="processus" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="R&D">R&D et développement clinique</option>
-                                    <option value="Achats">Achats et approvisionnements</option>
-                                    <option value="Marketing">Marketing et communication</option>
-                                    <option value="Ventes">Ventes et relations clients</option>
-                                    <option value="RH">Ressources humaines</option>
                                 </select>
                             </div>
                             <div class="form-group">
                                 <label class="form-label required">Type de Corruption</label>
                                 <select class="form-select" id="typeCorruption" required>
                                     <option value="">Sélectionner...</option>
-                                    <option value="active">Corruption active</option>
-                                    <option value="passive">Corruption passive</option>
-                                    <option value="trafic">Trafic d'influence</option>
-                                    <option value="favoritisme">Favoritisme</option>
-                                    <option value="cadeaux">Cadeaux/avantages indus</option>
                                 </select>
                             </div>
                         </div>
@@ -602,11 +575,6 @@
                             <div class="form-group" style="grid-column: 1 / -1;">
                                 <label class="form-label">Tiers concernés</label>
                                 <select class="form-select" id="tiers" multiple size="5">
-                                    <option value="Professionnels de santé">Professionnels de santé</option>
-                                    <option value="Institutionnels">Institutionnels</option>
-                                    <option value="Acheteurs">Acheteurs</option>
-                                    <option value="Politiques">Politiques</option>
-                                    <option value="Collaborateurs">Collaborateurs</option>
                                 </select>
                             </div>
                         </div>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Application de cartographie des risques corruption.
 - **Contrôles et mesures** : gestion des contrôles, association aux risques et suivi de l'efficacité.
 - **Rapports** : génération et export des données en PDF ou CSV.
 - **Historique** : suivi chronologique des actions effectuées.
+- **Configuration** : administration des options des listes déroulantes.
 
 ## Utilisation hors-ligne
 
@@ -22,3 +23,7 @@ Pour ouvrir l'application sans serveur local ni connexion Internet :
 2. Ouvrez directement le fichier `CartoModel.html` dans votre navigateur.
 
 Toutes les dépendances sont chargées localement, l'application peut donc fonctionner via `file://`.
+
+## Configuration
+
+L'onglet **Configuration** permet d'ajouter ou de supprimer les valeurs utilisées dans les listes déroulantes des formulaires (processus, types de risque, statuts, etc.). Les modifications sont conservées dans le navigateur grâce au stockage local.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1398,7 +1398,24 @@ tbody tr:hover {
         display: none;
     }
     
-    .matrix-container {
-        page-break-inside: avoid;
-    }
+.matrix-container {
+    page-break-inside: avoid;
+}
+}
+
+.config-section {
+    margin-bottom: 20px;
+}
+
+.config-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+.config-list li {
+    margin: 4px 0;
+}
+
+.config-add input {
+    margin-right: 5px;
 }

--- a/assets/js/rms.js
+++ b/assets/js/rms.js
@@ -4,6 +4,7 @@ class RiskManagementSystem {
         this.risks = this.loadData('risks') || this.getDefaultRisks();
         this.controls = this.loadData('controls') || this.getDefaultControls();
         this.history = this.loadData('history') || [];
+        this.config = this.loadConfig() || this.getDefaultConfig();
         this.currentView = 'brut';
         this.currentTab = 'dashboard';
         this.filters = {
@@ -16,6 +17,7 @@ class RiskManagementSystem {
     }
 
     init() {
+        this.populateSelects();
         this.initializeMatrix();
         this.updateDashboard();
         this.updateRisksList();
@@ -216,6 +218,177 @@ class RiskManagementSystem {
                 dateCreation: "2024-01-01"
             }
         ];
+    }
+
+    getDefaultConfig() {
+        return {
+            processes: [
+                { value: 'R&D', label: 'R&D' },
+                { value: 'Achats', label: 'Achats' },
+                { value: 'Marketing', label: 'Marketing' },
+                { value: 'Ventes', label: 'Ventes' },
+                { value: 'RH', label: 'RH' }
+            ],
+            riskTypes: [
+                { value: 'active', label: 'Corruption active' },
+                { value: 'passive', label: 'Corruption passive' },
+                { value: 'trafic', label: "Trafic d'influence" },
+                { value: 'favoritisme', label: 'Favoritisme' },
+                { value: 'cadeaux', label: 'Cadeaux/avantages indus' }
+            ],
+            tiers: [
+                { value: 'Professionnels de santé', label: 'Professionnels de santé' },
+                { value: 'Institutionnels', label: 'Institutionnels' },
+                { value: 'Acheteurs', label: 'Acheteurs' },
+                { value: 'Politiques', label: 'Politiques' },
+                { value: 'Collaborateurs', label: 'Collaborateurs' }
+            ],
+            riskStatuses: [
+                { value: 'nouveau', label: 'Nouveau' },
+                { value: 'en-cours', label: 'En cours de traitement' },
+                { value: 'traite', label: 'Traité' },
+                { value: 'archive', label: 'Archivé' }
+            ],
+            controlTypes: [
+                { value: 'preventif', label: 'Préventif' },
+                { value: 'detectif', label: 'Détectif' }
+            ],
+            controlFrequencies: [
+                { value: 'quotidienne', label: 'Quotidienne' },
+                { value: 'mensuelle', label: 'Mensuelle' },
+                { value: 'annuelle', label: 'Annuelle' },
+                { value: 'ad-hoc', label: 'Ad hoc' }
+            ],
+            controlModes: [
+                { value: 'manuel', label: 'Manuel' },
+                { value: 'automatise', label: 'Automatisé' }
+            ],
+            controlEffectiveness: [
+                { value: 'forte', label: 'Forte' },
+                { value: 'moyenne', label: 'Moyenne' },
+                { value: 'faible', label: 'Faible' }
+            ],
+            controlStatuses: [
+                { value: 'actif', label: 'Actif' },
+                { value: 'en-mise-en-place', label: 'En mise en place' },
+                { value: 'en-revision', label: 'En cours de révision' },
+                { value: 'obsolete', label: 'Obsolète' }
+            ]
+        };
+    }
+
+    loadConfig() {
+        const data = localStorage.getItem('rms_config');
+        return data ? JSON.parse(data) : null;
+    }
+
+    saveConfig() {
+        localStorage.setItem('rms_config', JSON.stringify(this.config));
+    }
+
+    populateSelects() {
+        const fill = (id, options, placeholder) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const current = el.value;
+            el.innerHTML = '';
+            if (placeholder !== undefined) {
+                const opt = document.createElement('option');
+                opt.value = '';
+                opt.textContent = placeholder;
+                el.appendChild(opt);
+            }
+            options.forEach(o => {
+                const opt = document.createElement('option');
+                opt.value = o.value;
+                opt.textContent = o.label;
+                el.appendChild(opt);
+            });
+            if (current && options.some(o => o.value === current)) {
+                el.value = current;
+            }
+        };
+
+        fill('processFilter', this.config.processes, 'Tous les processus');
+        fill('riskTypeFilter', this.config.riskTypes, 'Tous les types');
+        fill('statusFilter', this.config.riskStatuses, 'Tous les statuts');
+        fill('processus', this.config.processes, 'Sélectionner...');
+        fill('typeCorruption', this.config.riskTypes, 'Sélectionner...');
+        fill('tiers', this.config.tiers);
+        fill('controlType', this.config.controlTypes, 'Sélectionner...');
+        fill('controlFrequency', this.config.controlFrequencies, 'Sélectionner...');
+        fill('controlMode', this.config.controlModes, 'Sélectionner...');
+        fill('controlEffectiveness', this.config.controlEffectiveness, 'Sélectionner...');
+        fill('controlStatus', this.config.controlStatuses, 'Sélectionner...');
+    }
+
+    renderConfiguration() {
+        const container = document.getElementById('configurationContainer');
+        if (!container) return;
+
+        const sections = {
+            processes: 'Processus',
+            riskTypes: 'Types de corruption',
+            tiers: 'Tiers',
+            riskStatuses: 'Statuts des risques',
+            controlTypes: 'Types de contrôle',
+            controlFrequencies: 'Fréquences des contrôles',
+            controlModes: "Modes d'exécution",
+            controlEffectiveness: 'Efficacités',
+            controlStatuses: 'Statuts des contrôles'
+        };
+
+        container.innerHTML = '';
+        Object.entries(sections).forEach(([key, label]) => {
+            const section = document.createElement('div');
+            section.className = 'config-section';
+            section.innerHTML = `
+                <h3>${label}</h3>
+                <ul id="list-${key}" class="config-list"></ul>
+                <div class="config-add">
+                    <input type="text" id="input-${key}-value" placeholder="valeur">
+                    <input type="text" id="input-${key}-label" placeholder="libellé">
+                    <button onclick="rms.addConfigOption('${key}')">Ajouter</button>
+                </div>
+            `;
+            container.appendChild(section);
+        });
+
+        this.refreshConfigLists();
+    }
+
+    refreshConfigLists() {
+        const updateList = (key) => {
+            const list = document.getElementById(`list-${key}`);
+            if (!list) return;
+            list.innerHTML = this.config[key]
+                .map((opt, idx) => `<li>${opt.label} (${opt.value}) <button onclick="rms.removeConfigOption('${key}', ${idx})">×</button></li>`)
+                .join('');
+        };
+
+        Object.keys(this.config).forEach(updateList);
+    }
+
+    addConfigOption(key) {
+        const valueInput = document.getElementById(`input-${key}-value`);
+        const labelInput = document.getElementById(`input-${key}-label`);
+        if (!valueInput || !labelInput) return;
+        const value = valueInput.value.trim();
+        const label = labelInput.value.trim();
+        if (!value || !label) return;
+        this.config[key].push({ value, label });
+        this.saveConfig();
+        this.populateSelects();
+        this.refreshConfigLists();
+        valueInput.value = '';
+        labelInput.value = '';
+    }
+
+    removeConfigOption(key, index) {
+        this.config[key].splice(index, 1);
+        this.saveConfig();
+        this.populateSelects();
+        this.refreshConfigLists();
     }
 
     // Data persistence
@@ -686,6 +859,8 @@ function switchTab(tabName) {
             rms.updateControlsList();
         } else if (tabName === 'history') {
             rms.updateHistory();
+        } else if (tabName === 'config') {
+            rms.renderConfiguration();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add persistent configuration object with default dropdown values
- populate form selects from configuration and expose UI to manage options
- document configuration usage and styling

## Testing
- `npm test` *(fails: could not find a `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c65db12c832e9aeadc62aa255e8b