### PR TITLE
feat: enable control selection for risks

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -545,6 +545,28 @@
         </div>
     </div>
 
+    <!-- Control Selector Modal for Risks -->
+    <div id="controlSelectorModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Sélectionner les contrôles associés</h2>
+                <span class="close" onclick="closeControlSelector()">&times;</span>
+            </div>
+            <div class="modal-body">
+                <div class="search-box">
+                    <input type="text" class="search-input" id="controlSearchInput" placeholder="Filtrer par ID ou nom..." onkeyup="filterControlsForRisk(this.value)">
+                </div>
+                <div class="risk-list" id="controlList">
+                    <!-- Control list populated by JavaScript -->
+                </div>
+            </div>
+            <div class="form-actions">
+                <button type="button" class="btn btn-secondary" onclick="closeControlSelector()">Annuler</button>
+                <button type="button" class="btn btn-primary" onclick="confirmControlSelection()">Confirmer</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Risk Form Modal -->
     <div id="riskModal" class="modal">
         <div class="modal-content">
@@ -670,11 +692,11 @@
                     <div class="form-section">
                         <div class="form-section-title">Contrôles Associés</div>
                         <div class="controls-section">
-                            <button type="button" class="btn btn-secondary" onclick="addControlToRisk()">
+                            <button type="button" class="btn btn-secondary" onclick="openControlSelector()">
                                 + Ajouter un contrôle
                             </button>
                             <div class="controls-grid" id="riskControls" style="margin-top: 15px;">
-                                <!-- Controls will be added here -->
+                                <!-- Selected controls will appear here -->
                             </div>
                         </div>
                     </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -857,6 +857,27 @@ tbody tr:hover {
     color: #ff6b6b;
 }
 
+.selected-control-item {
+    display: inline-block;
+    background: var(--primary-color);
+    color: white;
+    padding: 5px 12px;
+    border-radius: 20px;
+    margin: 5px 5px 5px 0;
+    font-size: 0.85em;
+    position: relative;
+}
+
+.selected-control-item .remove-control {
+    margin-left: 8px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.selected-control-item .remove-control:hover {
+    color: #ff6b6b;
+}
+
 .risk-list {
     max-height: 400px;
     overflow-y: auto;


### PR DESCRIPTION
## Summary
- add modal to search and select controls from risk form
- link selected controls to risks and update control associations
- style selected controls in risk form

## Testing
- `node --check assets/js/rms.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f57ce4d4832e9a7e3dce26e6581b