### PR TITLE
feat: add subprocess selection for risks

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -313,6 +313,7 @@
                                     <th>ID</th>
                                     <th>Description</th>
                                     <th>Processus</th>
+                                    <th>Sous-processus</th>
                                     <th>Type</th>
                                     <th>Tiers</th>
                                     <th>Score Brut</th>
@@ -581,10 +582,19 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label class="form-label required">Processus</label>
-                                <select class="form-select" id="processus" required>
+                                <select class="form-select" id="processus" required onchange="rms.updateSousProcessusOptions()">
                                     <option value="">Sélectionner...</option>
                                 </select>
                             </div>
+                            <div class="form-group">
+                                <label class="form-label">Sous-processus</label>
+                                <select class="form-select" id="sousProcessus">
+                                    <option value="">Sélectionner...</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-grid">
                             <div class="form-group">
                                 <label class="form-label required">Type de Corruption</label>
                                 <select class="form-select" id="typeCorruption" required>


### PR DESCRIPTION
## Summary
- allow choosing a sub-process when creating or editing a risk
- manage sub-process lists per process in configuration and persist them
- display selected sub-process in risk listings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f810219c832eb8746193aac59ce3