### PR TITLE
chore: enforce net risk bounds

### DIFF
--- a/assets/js/rms.js
+++ b/assets/js/rms.js
@@ -1237,6 +1237,11 @@ function saveRisk() {
         return;
     }
 
+    if (formData.probNet > formData.probBrut || formData.impactNet > formData.impactBrut) {
+        showNotification('error', 'La probabilité et l\'impact nets doivent être inférieurs ou égaux aux valeurs brutes');
+        return;
+    }
+
     if (currentEditingRiskId) {
         const riskIndex = rms.risks.findIndex(r => r.id === currentEditingRiskId);
         if (riskIndex !== -1) {
@@ -1421,6 +1426,30 @@ function bindEvents() {
             }
         });
     });
+
+    // Ensure net probability and impact do not exceed gross values
+    const probBrut = document.getElementById('probBrut');
+    const probNet = document.getElementById('probNet');
+    const impactBrut = document.getElementById('impactBrut');
+    const impactNet = document.getElementById('impactNet');
+
+    const enforceNetLimits = () => {
+        if (parseInt(probNet.value) > parseInt(probBrut.value)) {
+            probNet.value = probBrut.value;
+        }
+        if (parseInt(impactNet.value) > parseInt(impactBrut.value)) {
+            impactNet.value = impactBrut.value;
+        }
+        calculateScore('net');
+    };
+
+    if (probBrut && probNet && impactBrut && impactNet) {
+        probBrut.addEventListener('change', enforceNetLimits);
+        probNet.addEventListener('change', enforceNetLimits);
+        impactBrut.addEventListener('change', enforceNetLimits);
+        impactNet.addEventListener('change', enforceNetLimits);
+        enforceNetLimits();
+    }
 
     // Handle control edit buttons
     document.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- prevent saving risks where net probability/impact exceed gross values
- keep net probability and impact selections bounded by gross values

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c6fb5fddf8832ea22f69aa8d8a3e7b