### PR TITLE
Augmente le z-index du sélecteur de contrôles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -762,6 +762,9 @@ tbody tr:hover {
 .modal.show {
     display: flex;
 }
+#controlSelectorModal {
+    z-index: 2100;
+}
 
 .modal-content {
     background: white;


### PR DESCRIPTION
## Summary
- ensure control selector modal appears above risk form by increasing its z-index

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server` & `curl -I http://localhost:8000/CartoModel.html`

------
https://chatgpt.com/codex/tasks/task_e_68c7058751ac832eb28e207e9fd82070