### PR TITLE
feat: conditionally display post-mitigation score

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -802,30 +802,6 @@
                                 <div class="risk-score-display" id="scoreNet">Score: 1</div>
                             </div>
 
-                            <div class="evaluation-card post-mitigation">
-                                <div class="evaluation-card-header" style="color: #27ae60;">Post-Mitigation</div>
-                                <div class="evaluation-inputs">
-                                    <div class="form-group">
-                                        <label class="form-label">Probabilité</label>
-                                        <select class="form-select" id="probPost" onchange="calculateScore('post')">
-                                            <option value="1">1 - Très rare</option>
-                                            <option value="2">2 - Peu probable</option>
-                                            <option value="3">3 - Probable</option>
-                                            <option value="4">4 - Très probable</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label">Impact</label>
-                                        <select class="form-select" id="impactPost" onchange="calculateScore('post')">
-                                            <option value="1">1 - Mineur</option>
-                                            <option value="2">2 - Modéré</option>
-                                            <option value="3">3 - Majeur</option>
-                                            <option value="4">4 - Critique</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <div class="risk-score-display" id="scorePost">Score: 1</div>
-                            </div>
                         </div>
                     </div>
 
@@ -850,6 +826,34 @@
                             <div class="controls-grid" id="riskActionPlans" style="margin-top: 15px;">
                                 <!-- Selected action plans will appear here -->
                             </div>
+                        </div>
+                    </div>
+
+                    <div class="form-section" id="postMitigationSection" style="display: none;">
+                        <div class="form-section-title">Score post-mitigation</div>
+                        <div class="evaluation-card post-mitigation">
+                            <div class="evaluation-card-header" style="color: #27ae60;">Post-Mitigation</div>
+                            <div class="evaluation-inputs">
+                                <div class="form-group">
+                                    <label class="form-label">Probabilité</label>
+                                    <select class="form-select" id="probPost" onchange="calculateScore('post')">
+                                        <option value="1">1 - Très rare</option>
+                                        <option value="2">2 - Peu probable</option>
+                                        <option value="3">3 - Probable</option>
+                                        <option value="4">4 - Très probable</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label class="form-label">Impact</label>
+                                    <select class="form-select" id="impactPost" onchange="calculateScore('post')">
+                                        <option value="1">1 - Mineur</option>
+                                        <option value="2">2 - Modéré</option>
+                                        <option value="3">3 - Majeur</option>
+                                        <option value="4">4 - Critique</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="risk-score-display" id="scorePost">Score: 1</div>
                         </div>
                     </div>
                 </form>

--- a/assets/js/rms.js
+++ b/assets/js/rms.js
@@ -20,6 +20,12 @@ class RiskManagementSystem {
             status: '',
             search: ''
         };
+        this.risks.forEach(r => {
+            if (!r.actionPlans || r.actionPlans.length === 0) {
+                r.probPost = r.probNet;
+                r.impactPost = r.impactNet;
+            }
+        });
         this.init();
     }
 
@@ -1263,8 +1269,14 @@ function calculateScore(type) {
     const prob = parseInt(document.getElementById(probId).value) || 1;
     const impact = parseInt(document.getElementById(impactId).value) || 1;
     const score = prob * impact;
-    
+
     document.getElementById(scoreId).textContent = `Score: ${score}`;
+
+    if (type === 'net' && selectedActionPlansForRisk.length === 0) {
+        document.getElementById('probPost').value = document.getElementById('probNet').value;
+        document.getElementById('impactPost').value = document.getElementById('impactNet').value;
+        document.getElementById('scorePost').textContent = `Score: ${score}`;
+    }
 }
 window.calculateScore = calculateScore;
 
@@ -1287,6 +1299,11 @@ function saveRisk() {
         controls: [...selectedControlsForRisk],
         actionPlans: [...selectedActionPlansForRisk]
     };
+
+    if (selectedActionPlansForRisk.length === 0) {
+        formData.probPost = formData.probNet;
+        formData.impactPost = formData.impactNet;
+    }
 
     // Validate form
     if (!formData.processus || !formData.description || !formData.typeCorruption) {
@@ -1451,9 +1468,16 @@ window.removeControlFromSelection = removeControlFromSelection;
 
 function updateSelectedActionPlansDisplay() {
     const container = document.getElementById('riskActionPlans');
+    const postSection = document.getElementById('postMitigationSection');
     if (!container) return;
     if (selectedActionPlansForRisk.length === 0) {
         container.innerHTML = '<div style="color: #7f8c8d; font-style: italic;">Aucun plan d\'action sélectionné</div>';
+        if (postSection) postSection.style.display = 'none';
+        const probNet = document.getElementById('probNet');
+        const impactNet = document.getElementById('impactNet');
+        document.getElementById('probPost').value = probNet ? probNet.value : 1;
+        document.getElementById('impactPost').value = impactNet ? impactNet.value : 1;
+        calculateScore('post');
         return;
     }
     container.innerHTML = selectedActionPlansForRisk.map(id => {
@@ -1466,6 +1490,7 @@ function updateSelectedActionPlansDisplay() {
               <span class="remove-control" onclick="removeActionPlanFromSelection(${id})">×</span>
             </div>`;
     }).join('');
+    if (postSection) postSection.style.display = 'block';
 }
 window.updateSelectedActionPlansDisplay = updateSelectedActionPlansDisplay;
 


### PR DESCRIPTION
## Summary
- show post-mitigation score section only when risk has linked action plans
- keep post-mitigation values in sync with net risk when no action plan is attached
- default existing risks without action plans to net values for post-mitigation score

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7105127d0832e8f4694fc741ce415