### PR TITLE
Fix z-index for action plan selector modal

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -762,7 +762,8 @@ tbody tr:hover {
 .modal.show {
     display: flex;
 }
-#controlSelectorModal {
+#controlSelectorModal,
+#actionPlanSelectorModal {
     z-index: 2100;
 }
 


### PR DESCRIPTION
## Summary
- ensure action plan selector modal overlays risk form by raising its z-index

## Testing
- `npm test` (fails: enoent package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c717c6d0e4832e8970b2bb2aac31bc