### PR TITLE
Fix action plan modal separation

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -667,7 +667,13 @@
                 </div>
                 <div class="risk-list" id="controlList">
                     <!-- Control list populated by JavaScript -->
-    </div>
+                </div>
+            </div>
+            <div class="form-actions">
+                <button type="button" class="btn btn-secondary" onclick="closeControlSelector()">Annuler</button>
+                <button type="button" class="btn btn-primary" onclick="confirmControlSelection()">Confirmer</button>
+            </div>
+        </div>
     </div>
 
     <!-- Action Plan Selector Modal for Risks -->
@@ -688,12 +694,6 @@
             <div class="form-actions">
                 <button type="button" class="btn btn-secondary" onclick="closeActionPlanSelector()">Annuler</button>
                 <button type="button" class="btn btn-primary" onclick="confirmActionPlanSelection()">Confirmer</button>
-            </div>
-        </div>
-    </div>
-            <div class="form-actions">
-                <button type="button" class="btn btn-secondary" onclick="closeControlSelector()">Annuler</button>
-                <button type="button" class="btn btn-primary" onclick="confirmControlSelection()">Confirmer</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- properly close control selector modal before other content
- move action plan selector modal outside the control selector

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c71e695cc8832e829981bced2bde65