### PR TITLE
Add interactive risk matrix editor

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -751,57 +751,49 @@
 
                     <div class="form-section">
                         <div class="form-section-title">Évaluation du Risque</div>
-                        <div class="evaluation-cards">
-                            <div class="evaluation-card brut">
-                                <div class="evaluation-card-header" style="color: #e74c3c;">Risque Brut</div>
-                                <div class="evaluation-inputs">
-                                    <div class="form-group">
-                                        <label class="form-label">Probabilité</label>
-                                        <select class="form-select" id="probBrut" onchange="calculateScore('brut')">
-                                            <option value="1">1 - Très rare</option>
-                                            <option value="2">2 - Peu probable</option>
-                                            <option value="3">3 - Probable</option>
-                                            <option value="4">4 - Très probable</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label">Impact</label>
-                                        <select class="form-select" id="impactBrut" onchange="calculateScore('brut')">
-                                            <option value="1">1 - Mineur</option>
-                                            <option value="2">2 - Modéré</option>
-                                            <option value="3">3 - Majeur</option>
-                                            <option value="4">4 - Critique</option>
-                                        </select>
+                        <div class="risk-matrix-editor">
+                            <div class="risk-state-selector">
+                                <button type="button" class="state-btn active" data-state="brut" onclick="setActiveRiskState('brut')">Risque Brut</button>
+                                <button type="button" class="state-btn" data-state="net" onclick="setActiveRiskState('net')">Risque Net</button>
+                                <button type="button" class="state-btn" data-state="post" onclick="setActiveRiskState('post')">Post-mitigation</button>
+                            </div>
+                            <div class="risk-matrix-layout">
+                                <div class="edit-matrix-container">
+                                    <div class="matrix edit-matrix" id="riskMatrixEdit">
+                                        <div class="matrix-grid" id="riskMatrixEditGrid"></div>
+                                        <div class="axis-label x-axis">Impact →</div>
+                                        <div class="axis-label y-axis">Probabilité →</div>
                                     </div>
                                 </div>
-                                <div class="risk-score-display" id="scoreBrut">Score: 1</div>
-                            </div>
-
-                            <div class="evaluation-card net">
-                                <div class="evaluation-card-header" style="color: #f39c12;">Risque Net</div>
-                                <div class="evaluation-inputs">
-                                    <div class="form-group">
-                                        <label class="form-label">Probabilité</label>
-                                        <select class="form-select" id="probNet" onchange="calculateScore('net')">
-                                            <option value="1">1 - Très rare</option>
-                                            <option value="2">2 - Peu probable</option>
-                                            <option value="3">3 - Probable</option>
-                                            <option value="4">4 - Très probable</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label class="form-label">Impact</label>
-                                        <select class="form-select" id="impactNet" onchange="calculateScore('net')">
-                                            <option value="1">1 - Mineur</option>
-                                            <option value="2">2 - Modéré</option>
-                                            <option value="3">3 - Majeur</option>
-                                            <option value="4">4 - Critique</option>
-                                        </select>
+                                <div id="matrixDescription" class="matrix-description">
+                                    <div class="matrix-description-empty">
+                                        Sélectionnez un état et déplacez le marqueur dans la matrice pour afficher les définitions de probabilité et d'impact.
                                     </div>
                                 </div>
-                                <div class="risk-score-display" id="scoreNet">Score: 1</div>
                             </div>
-
+                            <div class="risk-score-cards">
+                                <div class="risk-score-card brut active" data-state="brut">
+                                    <div class="risk-score-title">Risque Brut</div>
+                                    <div class="risk-score-value" id="scoreBrut">Score: 1</div>
+                                    <div class="risk-score-meta" id="coordBrut">P1 × I1</div>
+                                </div>
+                                <div class="risk-score-card net" data-state="net">
+                                    <div class="risk-score-title">Risque Net</div>
+                                    <div class="risk-score-value" id="scoreNet">Score: 1</div>
+                                    <div class="risk-score-meta" id="coordNet">P1 × I1</div>
+                                </div>
+                                <div class="risk-score-card post" data-state="post">
+                                    <div class="risk-score-title">Post-mitigation</div>
+                                    <div class="risk-score-value" id="scorePost">Score: 1</div>
+                                    <div class="risk-score-meta" id="coordPost">P1 × I1</div>
+                                </div>
+                            </div>
+                            <input type="hidden" id="probBrut" value="1">
+                            <input type="hidden" id="impactBrut" value="1">
+                            <input type="hidden" id="probNet" value="1">
+                            <input type="hidden" id="impactNet" value="1">
+                            <input type="hidden" id="probPost" value="1">
+                            <input type="hidden" id="impactPost" value="1">
                         </div>
                     </div>
 
@@ -829,33 +821,6 @@
                         </div>
                     </div>
 
-                    <div class="form-section" id="postMitigationSection" style="display: none;">
-                        <div class="form-section-title">Score post-mitigation</div>
-                        <div class="evaluation-card post-mitigation">
-                            <div class="evaluation-card-header" style="color: #27ae60;">Post-Mitigation</div>
-                            <div class="evaluation-inputs">
-                                <div class="form-group">
-                                    <label class="form-label">Probabilité</label>
-                                    <select class="form-select" id="probPost" onchange="calculateScore('post')">
-                                        <option value="1">1 - Très rare</option>
-                                        <option value="2">2 - Peu probable</option>
-                                        <option value="3">3 - Probable</option>
-                                        <option value="4">4 - Très probable</option>
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="form-label">Impact</label>
-                                    <select class="form-select" id="impactPost" onchange="calculateScore('post')">
-                                        <option value="1">1 - Mineur</option>
-                                        <option value="2">2 - Modéré</option>
-                                        <option value="3">3 - Majeur</option>
-                                        <option value="4">4 - Critique</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="risk-score-display" id="scorePost">Score: 1</div>
-                        </div>
-                    </div>
                 </form>
             </div>
             <div class="modal-footer">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -428,8 +428,241 @@ body {
 .risk-point.net { 
     background: linear-gradient(135deg, #f39c12, #d68910); 
 }
-.risk-point.post-mitigation { 
-    background: linear-gradient(135deg, #27ae60, #229954); 
+.risk-point.post-mitigation {
+    background: linear-gradient(135deg, #27ae60, #229954);
+}
+
+.risk-point.post {
+    background: linear-gradient(135deg, #27ae60, #229954);
+}
+
+.risk-point.inactive {
+    background: linear-gradient(135deg, #d5d8dc, #bdc3c7);
+    border-color: #f0f3f4;
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+}
+
+.risk-point.edit-point {
+    width: 28px;
+    height: 28px;
+    border-width: 3px;
+    cursor: grab;
+}
+
+.risk-point.edit-point.dragging {
+    cursor: grabbing;
+    transform: scale(1.1);
+}
+
+.risk-matrix-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-top: 10px;
+}
+
+.risk-state-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.state-btn {
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+    background: #ecf0f1;
+    color: #2c3e50;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.state-btn:hover {
+    background: #dce6f7;
+}
+
+.state-btn.active {
+    background: var(--primary-color);
+    color: white;
+    box-shadow: 0 6px 18px rgba(52, 152, 219, 0.3);
+}
+
+.risk-matrix-layout {
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    align-items: stretch;
+}
+
+.edit-matrix-container {
+    flex: 1;
+    min-width: 260px;
+    display: flex;
+    justify-content: center;
+}
+
+.matrix.edit-matrix {
+    width: min(420px, 100%);
+    height: auto;
+    aspect-ratio: 1 / 1;
+    border-width: 1px;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.08);
+}
+
+.matrix.edit-matrix .matrix-grid {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.matrix.edit-matrix .axis-label.x-axis {
+    bottom: -30px;
+    font-size: 0.9em;
+}
+
+.matrix.edit-matrix .axis-label.y-axis {
+    left: -55px;
+    font-size: 0.9em;
+}
+
+.matrix-description {
+    flex: 1;
+    min-width: 260px;
+    background: white;
+    border-radius: var(--border-radius);
+    border: 1px solid #e1e8ed;
+    padding: 20px;
+    box-shadow: 0 6px 20px rgba(0,0,0,0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.matrix-description-header {
+    font-weight: 600;
+    color: #2c3e50;
+    font-size: 1.1em;
+}
+
+.matrix-description-section h4 {
+    margin-bottom: 6px;
+    color: #2c3e50;
+    font-size: 1em;
+}
+
+.matrix-description-section p {
+    color: #596069;
+    line-height: 1.45;
+    font-size: 0.95em;
+}
+
+.matrix-description-empty {
+    color: #7f8c8d;
+    font-style: italic;
+    line-height: 1.5;
+}
+
+.risk-score-cards {
+    display: flex;
+    gap: 15px;
+    flex-wrap: wrap;
+}
+
+.risk-score-card {
+    flex: 1;
+    min-width: 200px;
+    background: white;
+    border-radius: var(--border-radius);
+    border: 2px solid transparent;
+    padding: 16px 18px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.08);
+    transition: all 0.3s ease;
+}
+
+.risk-score-card.brut {
+    border-color: rgba(231, 76, 60, 0.3);
+}
+
+.risk-score-card.net {
+    border-color: rgba(243, 156, 18, 0.3);
+}
+
+.risk-score-card.post {
+    border-color: rgba(39, 174, 96, 0.3);
+}
+
+.risk-score-card.active {
+    border-color: var(--primary-color);
+    box-shadow: 0 6px 20px rgba(52, 152, 219, 0.25);
+}
+
+.risk-score-title {
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 6px;
+}
+
+.risk-score-value {
+    font-size: 1.2em;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 4px;
+}
+
+.risk-score-meta {
+    color: #7f8c8d;
+    font-size: 0.9em;
+}
+
+.matrix-cell.drag-hover {
+    outline: 3px solid var(--primary-color);
+    outline-offset: -3px;
+    box-shadow: inset 0 0 12px rgba(52, 152, 219, 0.3);
+}
+
+@media (max-width: 1024px) {
+    .risk-matrix-layout {
+        flex-direction: column;
+    }
+
+    .edit-matrix-container {
+        justify-content: flex-start;
+    }
+
+    .matrix.edit-matrix {
+        width: 100%;
+    }
+
+    .matrix.edit-matrix .axis-label.y-axis {
+        left: -45px;
+    }
+}
+
+@media (max-width: 600px) {
+    .risk-score-cards {
+        flex-direction: column;
+    }
+
+    .risk-score-card {
+        min-width: unset;
+        width: 100%;
+    }
+
+    .state-btn {
+        flex: 1 1 100px;
+    }
+
+    .matrix.edit-matrix .axis-label.y-axis {
+        left: -40px;
+    }
 }
 
 .axis-label {

--- a/assets/js/rms.js
+++ b/assets/js/rms.js
@@ -5,6 +5,78 @@ function sanitizeId(str) {
     return str.replace(/[^a-z0-9_-]/gi, '_');
 }
 
+const RISK_PROBABILITY_INFO = {
+    1: {
+        label: 'Très rare',
+        text: "Situation exceptionnelle nécessitant une combinaison d'événements peu plausibles et sans cas recensé récemment."
+    },
+    2: {
+        label: 'Peu probable',
+        text: "Peut survenir de façon isolée lorsque plusieurs facteurs se cumulent ; occurrence envisageable à moyen terme."
+    },
+    3: {
+        label: 'Probable',
+        text: "Déjà observé ponctuellement ; les conditions favorables existent et les signaux faibles sont identifiés."
+    },
+    4: {
+        label: 'Très probable',
+        text: "Événement attendu à court terme en l'absence d'action ; les contrôles actuels ne suffisent pas à le prévenir."
+    }
+};
+
+const RISK_IMPACT_INFO = {
+    1: {
+        label: 'Mineur',
+        text: "Conséquences limitées, facilement réversibles et sans effet notable sur les activités ou la réputation."
+    },
+    2: {
+        label: 'Modéré',
+        text: "Incident gérable avec des efforts supplémentaires ; impacts financiers ou opérationnels contenus."
+    },
+    3: {
+        label: 'Majeur',
+        text: "Perturbation significative de l'activité ou des relations externes avec exposition médiatique possible."
+    },
+    4: {
+        label: 'Critique',
+        text: "Atteinte grave à la continuité, sanctions réglementaires majeures ou dommages durables à la réputation."
+    }
+};
+
+const RISK_STATE_CONFIG = {
+    brut: {
+        label: 'Risque Brut',
+        probInput: 'probBrut',
+        impactInput: 'impactBrut',
+        scoreElement: 'scoreBrut',
+        coordElement: 'coordBrut',
+        pointClass: 'brut'
+    },
+    net: {
+        label: 'Risque Net',
+        probInput: 'probNet',
+        impactInput: 'impactNet',
+        scoreElement: 'scoreNet',
+        coordElement: 'coordNet',
+        pointClass: 'net'
+    },
+    post: {
+        label: 'Post-mitigation',
+        probInput: 'probPost',
+        impactInput: 'impactPost',
+        scoreElement: 'scorePost',
+        coordElement: 'coordPost',
+        pointClass: 'post'
+    }
+};
+
+let activeRiskEditState = 'brut';
+const editMatrixPoints = {};
+let highlightedEditCell = null;
+let currentDragState = null;
+let currentPointerId = null;
+let lastDragCell = null;
+
 class RiskManagementSystem {
     constructor() {
         this.risks = this.loadData('risks') || this.getDefaultRisks();
@@ -1034,7 +1106,12 @@ class RiskManagementSystem {
         updateSelectedControlsDisplay();
         updateSelectedActionPlansDisplay();
 
-        document.getElementById('riskModal').classList.add('show');
+        activeRiskEditState = 'brut';
+        const modal = document.getElementById('riskModal');
+        if (modal) {
+            modal.classList.add('show');
+            requestAnimationFrame(() => initRiskEditMatrix());
+        }
     }
 
     deleteRisk(riskId) {
@@ -1258,7 +1335,12 @@ function addNewRisk() {
         updateSelectedControlsDisplay();
         updateSelectedActionPlansDisplay();
     }
-    document.getElementById('riskModal').classList.add('show');
+    activeRiskEditState = 'brut';
+    const modal = document.getElementById('riskModal');
+    if (modal) {
+        modal.classList.add('show');
+        requestAnimationFrame(() => initRiskEditMatrix());
+    }
 }
 window.addNewRisk = addNewRisk;
 
@@ -1268,35 +1350,308 @@ function closeModal(modalId) {
 window.closeModal = closeModal;
 
 function calculateScore(type) {
-    let probId, impactId, scoreId;
-    
-    if (type === 'brut') {
-        probId = 'probBrut';
-        impactId = 'impactBrut';
-        scoreId = 'scoreBrut';
-    } else if (type === 'net') {
-        probId = 'probNet';
-        impactId = 'impactNet';
-        scoreId = 'scoreNet';
-    } else {
-        probId = 'probPost';
-        impactId = 'impactPost';
-        scoreId = 'scorePost';
-    }
-    
-    const prob = parseInt(document.getElementById(probId).value) || 1;
-    const impact = parseInt(document.getElementById(impactId).value) || 1;
+    const stateKey = type === 'post' ? 'post' : type;
+    const config = RISK_STATE_CONFIG[stateKey];
+    if (!config) return;
+
+    const probInput = document.getElementById(config.probInput);
+    const impactInput = document.getElementById(config.impactInput);
+    if (!probInput || !impactInput) return;
+
+    const prob = parseInt(probInput.value, 10) || 1;
+    const impact = parseInt(impactInput.value, 10) || 1;
     const score = prob * impact;
 
-    document.getElementById(scoreId).textContent = `Score: ${score}`;
+    const scoreElement = document.getElementById(config.scoreElement);
+    if (scoreElement) {
+        scoreElement.textContent = `Score: ${score}`;
+    }
+
+    const coordElement = document.getElementById(config.coordElement);
+    if (coordElement) {
+        coordElement.textContent = `P${prob} × I${impact}`;
+    }
+
+    positionRiskPointIfExists(stateKey, prob, impact);
+
+    if (activeRiskEditState === stateKey) {
+        highlightCell(prob, impact);
+        updateMatrixDescription(prob, impact, stateKey);
+    }
 
     if (type === 'net' && selectedActionPlansForRisk.length === 0) {
-        document.getElementById('probPost').value = document.getElementById('probNet').value;
-        document.getElementById('impactPost').value = document.getElementById('impactNet').value;
-        document.getElementById('scorePost').textContent = `Score: ${score}`;
+        const postConfig = RISK_STATE_CONFIG.post;
+        if (postConfig) {
+            const postProbInput = document.getElementById(postConfig.probInput);
+            const postImpactInput = document.getElementById(postConfig.impactInput);
+            if (postProbInput) postProbInput.value = prob;
+            if (postImpactInput) postImpactInput.value = impact;
+            calculateScore('post');
+        }
     }
 }
 window.calculateScore = calculateScore;
+
+function getStateValues(state) {
+    const config = RISK_STATE_CONFIG[state];
+    if (!config) {
+        return { prob: 1, impact: 1 };
+    }
+    const prob = parseInt(document.getElementById(config.probInput)?.value, 10) || 1;
+    const impact = parseInt(document.getElementById(config.impactInput)?.value, 10) || 1;
+    return { prob, impact };
+}
+
+function setStateValues(state, prob, impact) {
+    const config = RISK_STATE_CONFIG[state];
+    if (!config) return;
+    const probInput = document.getElementById(config.probInput);
+    const impactInput = document.getElementById(config.impactInput);
+    if (probInput) probInput.value = prob;
+    if (impactInput) impactInput.value = impact;
+    calculateScore(state === 'post' ? 'post' : state);
+}
+
+function positionRiskPointIfExists(state, prob, impact) {
+    if (!editMatrixPoints[state]) return;
+    const values = (typeof prob === 'number' && typeof impact === 'number')
+        ? { prob, impact }
+        : getStateValues(state);
+    positionRiskPoint(state, values.prob, values.impact);
+}
+
+function positionRiskPoint(state, prob, impact) {
+    const matrix = document.getElementById('riskMatrixEdit');
+    const point = editMatrixPoints[state];
+    if (!matrix || !point) return;
+
+    const rect = matrix.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+        requestAnimationFrame(() => positionRiskPoint(state, prob, impact));
+        return;
+    }
+
+    const cellWidth = rect.width / 4;
+    const cellHeight = rect.height / 4;
+    const left = (impact - 0.5) * cellWidth;
+    const top = (4 - prob + 0.5) * cellHeight;
+
+    point.style.left = `${left}px`;
+    point.style.top = `${top}px`;
+    point.style.transform = 'translate(-50%, -50%)';
+}
+
+function positionAllPoints() {
+    if (!Object.keys(editMatrixPoints).length) return;
+    const matrix = document.getElementById('riskMatrixEdit');
+    if (!matrix) return;
+    const rect = matrix.getBoundingClientRect();
+    if (!rect.width || !rect.height) return;
+    Object.keys(RISK_STATE_CONFIG).forEach(state => {
+        const { prob, impact } = getStateValues(state);
+        positionRiskPoint(state, prob, impact);
+    });
+}
+
+function clearHighlightedCell() {
+    if (highlightedEditCell) {
+        highlightedEditCell.classList.remove('drag-hover');
+        highlightedEditCell = null;
+    }
+}
+
+function highlightCell(prob, impact) {
+    const grid = document.getElementById('riskMatrixEditGrid');
+    if (!grid) return;
+
+    clearHighlightedCell();
+
+    const selector = `.matrix-cell[data-probability="${prob}"][data-impact="${impact}"]`;
+    const cell = grid.querySelector(selector);
+    if (cell) {
+        cell.classList.add('drag-hover');
+        highlightedEditCell = cell;
+    }
+}
+
+function updateMatrixDescription(prob, impact, state = activeRiskEditState) {
+    const container = document.getElementById('matrixDescription');
+    const stateConfig = RISK_STATE_CONFIG[state];
+    if (!container || !stateConfig) return;
+
+    const probability = RISK_PROBABILITY_INFO[prob];
+    const impactInfo = RISK_IMPACT_INFO[impact];
+
+    if (!probability || !impactInfo) {
+        container.innerHTML = `
+            <div class="matrix-description-header">${stateConfig.label}</div>
+            <div class="matrix-description-empty">Déplacez le marqueur pour obtenir les définitions détaillées.</div>
+        `;
+        return;
+    }
+
+    container.innerHTML = `
+        <div class="matrix-description-header">${stateConfig.label}</div>
+        <div class="matrix-description-section">
+            <h4>Probabilité ${prob} – ${probability.label}</h4>
+            <p>${probability.text}</p>
+        </div>
+        <div class="matrix-description-section">
+            <h4>Impact ${impact} – ${impactInfo.label}</h4>
+            <p>${impactInfo.text}</p>
+        </div>
+    `;
+}
+
+function updateStateButtons() {
+    document.querySelectorAll('.state-btn').forEach(btn => {
+        const state = btn.dataset.state;
+        btn.classList.toggle('active', state === activeRiskEditState);
+    });
+}
+
+function updateScoreCardState() {
+    document.querySelectorAll('.risk-score-card').forEach(card => {
+        const state = card.dataset.state;
+        card.classList.toggle('active', state === activeRiskEditState);
+    });
+}
+
+function updatePointsVisualState() {
+    Object.entries(editMatrixPoints).forEach(([state, point]) => {
+        if (!point) return;
+        if (state === activeRiskEditState) {
+            point.classList.remove('inactive');
+        } else {
+            point.classList.add('inactive');
+        }
+    });
+}
+
+function setActiveRiskState(state) {
+    if (!RISK_STATE_CONFIG[state]) return;
+    activeRiskEditState = state;
+    updateStateButtons();
+    updateScoreCardState();
+    updatePointsVisualState();
+    const { prob, impact } = getStateValues(state);
+    highlightCell(prob, impact);
+    updateMatrixDescription(prob, impact, state);
+    positionAllPoints();
+}
+window.setActiveRiskState = setActiveRiskState;
+
+function getCellFromEvent(event, matrix) {
+    if (!matrix) return null;
+    const rect = matrix.getBoundingClientRect();
+    if (!rect.width || !rect.height) return null;
+
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    if (x < 0 || y < 0 || x > rect.width || y > rect.height) {
+        return null;
+    }
+
+    const col = Math.min(4, Math.max(1, Math.ceil(x / (rect.width / 4))));
+    const rowIndex = Math.min(3, Math.max(0, Math.floor(y / (rect.height / 4))));
+    const prob = 4 - rowIndex;
+    return { prob, impact: col };
+}
+
+function startPointDrag(event) {
+    const point = event.currentTarget;
+    const state = point.dataset.state;
+    if (state !== activeRiskEditState) return;
+
+    currentDragState = state;
+    currentPointerId = event.pointerId;
+    lastDragCell = null;
+    point.setPointerCapture(currentPointerId);
+    point.classList.add('dragging');
+    event.preventDefault();
+}
+
+function handlePointMove(event) {
+    if (!currentDragState || event.pointerId !== currentPointerId) return;
+    const matrix = document.getElementById('riskMatrixEdit');
+    const cell = getCellFromEvent(event, matrix);
+    if (!cell) return;
+
+    if (!lastDragCell || lastDragCell.prob !== cell.prob || lastDragCell.impact !== cell.impact) {
+        lastDragCell = cell;
+        setStateValues(currentDragState, cell.prob, cell.impact);
+    }
+}
+
+function finishPointDrag(event) {
+    if (!currentDragState || event.pointerId !== currentPointerId) return;
+    const state = currentDragState;
+    const point = event.currentTarget;
+    point.releasePointerCapture(currentPointerId);
+    point.classList.remove('dragging');
+
+    const matrix = document.getElementById('riskMatrixEdit');
+    const cell = getCellFromEvent(event, matrix) || lastDragCell || getStateValues(state);
+    if (cell) {
+        setStateValues(state, cell.prob, cell.impact);
+    }
+
+    currentDragState = null;
+    currentPointerId = null;
+    lastDragCell = null;
+}
+
+function initRiskEditMatrix() {
+    const matrix = document.getElementById('riskMatrixEdit');
+    const grid = document.getElementById('riskMatrixEditGrid');
+    if (!matrix || !grid) return;
+
+    grid.innerHTML = '';
+
+    for (let prob = 4; prob >= 1; prob--) {
+        for (let impact = 1; impact <= 4; impact++) {
+            const cell = document.createElement('div');
+            cell.className = 'matrix-cell';
+            cell.dataset.probability = prob;
+            cell.dataset.impact = impact;
+
+            const riskLevel = prob * impact;
+            if (riskLevel <= 4) cell.classList.add('level-1');
+            else if (riskLevel <= 8) cell.classList.add('level-2');
+            else if (riskLevel <= 12) cell.classList.add('level-3');
+            else cell.classList.add('level-4');
+
+            grid.appendChild(cell);
+        }
+    }
+
+    Object.keys(editMatrixPoints).forEach(state => {
+        const point = editMatrixPoints[state];
+        if (point && point.parentNode) {
+            point.parentNode.removeChild(point);
+        }
+        delete editMatrixPoints[state];
+    });
+
+    Object.entries(RISK_STATE_CONFIG).forEach(([state, config]) => {
+        const point = document.createElement('div');
+        point.className = `risk-point ${config.pointClass} edit-point`;
+        point.dataset.state = state;
+        point.addEventListener('pointerdown', startPointDrag);
+        point.addEventListener('pointermove', handlePointMove);
+        point.addEventListener('pointerup', finishPointDrag);
+        point.addEventListener('pointercancel', finishPointDrag);
+        matrix.appendChild(point);
+        editMatrixPoints[state] = point;
+    });
+
+    const initialState = RISK_STATE_CONFIG[activeRiskEditState] ? activeRiskEditState : 'brut';
+    setActiveRiskState(initialState);
+    requestAnimationFrame(() => positionAllPoints());
+}
+
+window.initRiskEditMatrix = initRiskEditMatrix;
+window.addEventListener('resize', () => positionAllPoints());
 
 function saveRisk() {
     if (!rms) return;
@@ -1396,6 +1751,11 @@ function saveRisk() {
         rms.updateActionPlansList();
         closeModal('riskModal');
         showNotification('success', 'Risque ajouté avec succès!');
+    }
+
+    if (rms) {
+        rms.renderRiskPoints();
+        rms.updateRiskDetailsList();
     }
 
     lastRiskData = { ...formData, tiers: [...formData.tiers], controls: [...formData.controls], actionPlans: [...formData.actionPlans] };


### PR DESCRIPTION
## Summary
- replace the risk evaluation form with an interactive matrix that lets users drag brut/net/post markers and displays contextual descriptions
- add styling for the matrix editor, state selector buttons, description panel, and active/inactive markers
- implement drag-and-drop state management, score updates, and matrix initialization so the modal and save flow stay in sync

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c90383c79c832eb172917fa24e4fbb