### PR TITLE
Add dynamic recent alerts rendering

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -147,41 +147,7 @@
                                     <th>Actions</th>
                                 </tr>
                             </thead>
-                            <tbody>
-                                <tr>
-                                    <td>08/01/2024</td>
-                                    <td>Corruption d'investigateurs cliniques</td>
-                                    <td>R&D</td>
-                                    <td><span class="table-badge badge-danger">Critique</span></td>
-                                    <td>Dr. Martin</td>
-                                    <td class="table-actions-cell">
-                                        <button class="action-btn">👁️</button>
-                                        <button class="action-btn">✏️</button>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>07/01/2024</td>
-                                    <td>Avantages indus - Congrès médical</td>
-                                    <td>Marketing</td>
-                                    <td><span class="table-badge badge-warning">Élevé</span></td>
-                                    <td>Mme. Leroy</td>
-                                    <td class="table-actions-cell">
-                                        <button class="action-btn">👁️</button>
-                                        <button class="action-btn">✏️</button>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>06/01/2024</td>
-                                    <td>Favoritisme fournisseurs</td>
-                                    <td>Achats</td>
-                                    <td><span class="table-badge badge-success">Modéré</span></td>
-                                    <td>M. Durand</td>
-                                    <td class="table-actions-cell">
-                                        <button class="action-btn">👁️</button>
-                                        <button class="action-btn">✏️</button>
-                                    </td>
-                                </tr>
-                            </tbody>
+                            <tbody id="recentAlertsBody"></tbody>
                         </table>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace the static recent alerts table body with a dynamic container
- add an `updateRecentAlerts` routine to populate high or critical risks without action plans
- trigger dashboard refresh after action plan edits or deletions so alerts stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c99594b050832e85cbce074a8f7475