### PR TITLE
Enable inline editing for configuration lists

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1672,6 +1672,42 @@ tbody tr:hover {
 
 .config-list li {
     margin: 4px 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.config-item-text {
+    flex: 1 1 auto;
+}
+
+.config-item-actions {
+    display: inline-flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-left: auto;
+}
+
+.config-list .btn {
+    padding: 6px 12px;
+    font-size: 0.8em;
+}
+
+.config-edit-form {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    width: 100%;
+}
+
+.config-edit-input {
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid #d0d7de;
+    font-size: 0.85em;
+    flex: 1 1 140px;
 }
 
 .config-add input {


### PR DESCRIPTION
## Summary
- add inline edit controls to configuration option lists and subprocess entries, including new update handlers to persist changes and refresh the UI
- propagate renamed processes/sub-processes to existing risk records and refresh the dashboard so data stays aligned with the configuration
- refine configuration list styling so edit/delete actions reuse the shared `.btn` styles and provide a compact inline edit form

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9b5bfd37c832e8e2cd94da281fe62