### PR TITLE
Add labels to risk points in creation matrix

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -414,6 +414,14 @@ body {
     border: 3px solid white;
     z-index: 10;
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: #fff;
+    line-height: 1;
+    user-select: none;
 }
 
 .risk-point:hover {

--- a/assets/js/rms.js
+++ b/assets/js/rms.js
@@ -72,7 +72,8 @@ const RISK_STATE_CONFIG = {
         impactInput: 'impactBrut',
         scoreElement: 'scoreBrut',
         coordElement: 'coordBrut',
-        pointClass: 'brut'
+        pointClass: 'brut',
+        symbol: 'B'
     },
     net: {
         label: 'Risque Net',
@@ -80,7 +81,8 @@ const RISK_STATE_CONFIG = {
         impactInput: 'impactNet',
         scoreElement: 'scoreNet',
         coordElement: 'coordNet',
-        pointClass: 'net'
+        pointClass: 'net',
+        symbol: 'N'
     },
     post: {
         label: 'Post-mitigation',
@@ -88,7 +90,8 @@ const RISK_STATE_CONFIG = {
         impactInput: 'impactPost',
         scoreElement: 'scorePost',
         coordElement: 'coordPost',
-        pointClass: 'post'
+        pointClass: 'post',
+        symbol: 'P'
     }
 };
 
@@ -2102,6 +2105,10 @@ function initRiskEditMatrix() {
         const point = document.createElement('div');
         point.className = `risk-point ${config.pointClass} edit-point`;
         point.dataset.state = state;
+        if (config.symbol) {
+            point.textContent = config.symbol;
+        }
+        point.setAttribute('aria-label', config.label);
         point.addEventListener('pointerdown', startPointDrag);
         point.addEventListener('pointermove', handlePointMove);
         point.addEventListener('pointerup', finishPointDrag);


### PR DESCRIPTION
## Summary
- add symbolic letters for each risk state configuration
- render the state letter inside edit-matrix markers and expose it for accessibility
- adjust risk-point styling so the letters are centered inside the circles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9c4619bb0832ebe91744bf402ac96