### PR TITLE
Fix tab activation when clicking tab badge

### DIFF
--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -28,12 +28,16 @@ function switchTab(tabNameOrEvent, maybeTabName) {
         selectedTab.classList.add('active');
     }
 
-    if (evt && evt.target) {
-        evt.target.classList.add('active');
-    } else {
-        const fallbackButton = document.querySelector(`.tab[onclick="switchTab('${tabName}')"]`);
-        fallbackButton && fallbackButton.classList.add('active');
+    let activeButton = null;
+    if (evt) {
+        activeButton = evt.currentTarget || (evt.target && evt.target.closest('.tab'));
     }
+
+    if (!activeButton) {
+        activeButton = document.querySelector(`.tab[onclick="switchTab('${tabName}')"]`);
+    }
+
+    activeButton && activeButton.classList.add('active');
 
     if (window.rms) {
         rms.currentTab = tabName;


### PR DESCRIPTION
## Summary
- update tab activation logic to use the event's currentTarget or closest tab button
- retain fallback lookup to ensure the correct tab is marked active when no event target is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca5952f650832eb77606b4e051de70