### PR TITLE
Permettre la modification du statut d'un risque

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -697,6 +697,12 @@
                                     <option value="">Sélectionner...</option>
                                 </select>
                             </div>
+                            <div class="form-group">
+                                <label class="form-label required">Statut du risque</label>
+                                <select class="form-select" id="statut" required>
+                                    <option value="">Sélectionner...</option>
+                                </select>
+                            </div>
                         </div>
 
                         <div class="form-grid">

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -352,6 +352,7 @@ class RiskManagementSystem {
                 { value: 'nouveau', label: 'Nouveau' },
                 { value: 'en-cours', label: 'En cours de traitement' },
                 { value: 'traite', label: 'Traité' },
+                { value: 'validé', label: 'Validé' },
                 { value: 'archive', label: 'Archivé' }
             ],
             controlTypes: [
@@ -420,6 +421,7 @@ class RiskManagementSystem {
         fill('processus', this.config.processes, 'Sélectionner...');
         this.updateSousProcessusOptions();
         fill('typeCorruption', this.config.riskTypes, 'Sélectionner...');
+        fill('statut', this.config.riskStatuses, 'Sélectionner...');
         fill('tiers', this.config.tiers);
         fill('controlType', this.config.controlTypes, 'Sélectionner...');
         fill('controlFrequency', this.config.controlFrequencies, 'Sélectionner...');
@@ -1437,7 +1439,7 @@ class RiskManagementSystem {
             id: getNextSequentialId(this.risks),
             ...riskData,
             dateCreation: new Date().toISOString(),
-            statut: 'nouveau'
+            statut: riskData.statut || 'nouveau'
         };
 
         this.risks.push(newRisk);
@@ -1462,6 +1464,24 @@ class RiskManagementSystem {
             this.updateSousProcessusOptions();
             document.getElementById('sousProcessus').value = risk.sousProcessus || '';
             document.getElementById('typeCorruption').value = risk.typeCorruption || '';
+            const statutSelect = document.getElementById('statut');
+            if (statutSelect) {
+                const defaultStatus = this.config?.riskStatuses?.[0]?.value || '';
+                const statusToApply = risk.statut || defaultStatus;
+                if (statusToApply) {
+                    const normalized = String(statusToApply);
+                    const hasOption = Array.from(statutSelect.options).some(opt => opt.value === normalized);
+                    if (!hasOption) {
+                        const option = document.createElement('option');
+                        option.value = normalized;
+                        option.textContent = normalized;
+                        statutSelect.appendChild(option);
+                    }
+                    statutSelect.value = normalized;
+                } else {
+                    statutSelect.value = '';
+                }
+            }
 
             const tiersSelect = document.getElementById('tiers');
             Array.from(tiersSelect.options).forEach(opt => {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -86,6 +86,7 @@ function addNewRisk() {
     if (form) {
         form.reset();
 
+        const statutSelect = document.getElementById('statut');
         if (lastRiskData) {
             document.getElementById('processus').value = lastRiskData.processus || '';
             rms.updateSousProcessusOptions();
@@ -110,6 +111,24 @@ function addNewRisk() {
             rms.updateSousProcessusOptions();
             selectedControlsForRisk = [];
             selectedActionPlansForRisk = [];
+        }
+
+        if (statutSelect) {
+            const defaultStatus = rms?.config?.riskStatuses?.[0]?.value || '';
+            const targetStatus = lastRiskData?.statut || defaultStatus;
+            if (targetStatus) {
+                const normalized = String(targetStatus);
+                const hasOption = Array.from(statutSelect.options).some(opt => opt.value === normalized);
+                if (!hasOption) {
+                    const option = document.createElement('option');
+                    option.value = normalized;
+                    option.textContent = normalized;
+                    statutSelect.appendChild(option);
+                }
+                statutSelect.value = normalized;
+            } else {
+                statutSelect.value = '';
+            }
         }
 
         calculateScore('brut');
@@ -141,6 +160,7 @@ function saveRisk() {
         sousProcessus: document.getElementById('sousProcessus').value,
         description: document.getElementById('description').value,
         typeCorruption: document.getElementById('typeCorruption').value,
+        statut: document.getElementById('statut').value,
         tiers: Array.from(document.getElementById('tiers').selectedOptions).map(o => o.value),
         probBrut: parseInt(document.getElementById('probBrut').value),
         impactBrut: parseInt(document.getElementById('impactBrut').value),
@@ -159,7 +179,7 @@ function saveRisk() {
     }
 
     // Validate form
-    if (!formData.processus || !formData.description || !formData.typeCorruption) {
+    if (!formData.processus || !formData.description || !formData.typeCorruption || !formData.statut) {
         showNotification('error', 'Veuillez remplir tous les champs obligatoires');
         return;
     }


### PR DESCRIPTION
## Summary
- ajoute le champ de sélection du statut dans le formulaire de création/édition d'un risque
- alimente la liste des statuts depuis la configuration et conserve les valeurs existantes lors de l'édition
- enregistre le statut choisi lors de la sauvegarde et complète les valeurs par défaut

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca5a42c848832eb6abe26b267f58d6