### PR TITLE
Prioritize active risk point in editor

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -448,8 +448,11 @@ body {
     background: linear-gradient(135deg, #d5d8dc, #bdc3c7);
     border-color: #f0f3f4;
     cursor: not-allowed;
-    opacity: 0.6;
     box-shadow: none;
+}
+
+.risk-point.active-point {
+    z-index: 30;
 }
 
 .risk-point.edit-point {

--- a/assets/js/rms.matrix.js
+++ b/assets/js/rms.matrix.js
@@ -239,11 +239,9 @@ function updateScoreCardState() {
 function updatePointsVisualState() {
     Object.entries(editMatrixPoints).forEach(([state, point]) => {
         if (!point) return;
-        if (state === activeRiskEditState) {
-            point.classList.remove('inactive');
-        } else {
-            point.classList.add('inactive');
-        }
+        const isActive = state === activeRiskEditState;
+        point.classList.toggle('inactive', !isActive);
+        point.classList.toggle('active-point', isActive);
     });
 }
 


### PR DESCRIPTION
## Summary
- ensure the selected risk state marker gets an explicit z-index boost
- remove transparency from inactive markers to keep lettering legible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca5d834f64832ea75b438197605bad