### PR TITLE
Improve controls tab layout

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -317,8 +317,17 @@
                 <div class="content-area">
                     <div class="controls-section">
                         <div class="form-section-title">Contrôles Actifs</div>
-                        <div class="controls-grid" id="controlsList">
-                            <!-- Populated by JavaScript -->
+                        <div class="controls-table">
+                            <div class="controls-table-header">
+                                <div>Nom du contrôle</div>
+                                <div>Type</div>
+                                <div>Propriétaire</div>
+                                <div>Statut</div>
+                                <div class="controls-table-actions">Actions</div>
+                            </div>
+                            <div class="controls-table-body" id="controlsList">
+                                <!-- Populated by JavaScript -->
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1434,6 +1434,143 @@ tbody tr:hover {
     gap: 15px;
 }
 
+.controls-table {
+    background: white;
+    border: 1px solid #e1e8ed;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 6px 18px rgba(52, 152, 219, 0.06);
+    margin-top: 15px;
+}
+
+.controls-table-header,
+.controls-table-row {
+    display: grid;
+    grid-template-columns: minmax(220px, 2fr) minmax(110px, 1fr) minmax(180px, 1.2fr) minmax(140px, 1fr) minmax(120px, 0.7fr);
+    gap: 16px;
+    align-items: center;
+    padding: 18px 22px;
+}
+
+.controls-table-header {
+    background: #f4f6fb;
+    color: #2c3e50;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.controls-table-header > div {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.controls-table-body {
+    display: flex;
+    flex-direction: column;
+    background: white;
+}
+
+.controls-table-row {
+    border-top: 1px solid #ecf0f6;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.controls-table-row:first-child {
+    border-top: none;
+}
+
+.controls-table-row:hover {
+    background: #f9fbff;
+    transform: translateX(2px);
+}
+
+.controls-table-cell {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #2c3e50;
+    font-size: 0.9rem;
+}
+
+.control-name-cell .control-name {
+    font-weight: 600;
+    font-size: 1rem;
+    color: #1f2d3d;
+}
+
+.control-type-cell .control-type-badge {
+    min-width: 105px;
+    text-align: center;
+}
+
+.control-owner-cell .control-owner {
+    font-weight: 500;
+    color: #34495e;
+}
+
+.control-status-cell .control-status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 120px;
+}
+
+.controls-table-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+}
+
+.controls-table-header .controls-table-actions {
+    justify-content: flex-end;
+    color: #7f8c8d;
+}
+
+.text-placeholder {
+    color: #95a5a6;
+    font-size: 0.85rem;
+    font-style: italic;
+}
+
+.control-type-badge.type-undefined {
+    background: rgba(149, 165, 166, 0.12);
+    color: #7f8c8d;
+}
+
+.controls-empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    background: white;
+    border: 1px dashed #cfd8e3;
+    border-radius: 12px;
+    color: #546a7b;
+}
+
+.controls-empty-title {
+    font-weight: 600;
+    margin-bottom: 8px;
+    font-size: 1rem;
+}
+
+.controls-empty-text {
+    font-size: 0.9rem;
+    margin-bottom: 16px;
+}
+
+@media (max-width: 992px) {
+    .controls-table {
+        overflow-x: auto;
+    }
+
+    .controls-table-header,
+    .controls-table-row {
+        min-width: 720px;
+    }
+}
+
 .control-item {
     background: white;
     padding: 15px;

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -1290,81 +1290,54 @@ class RiskManagementSystem {
     updateControlsList() {
         const container = document.getElementById('controlsList');
         if (!container) return;
-        
+
+        if (!this.controls.length) {
+            container.innerHTML = `
+                <div class="controls-empty-state">
+                    <div class="controls-empty-title">Aucun contrôle enregistré</div>
+                    <div class="controls-empty-text">Ajoutez votre premier contrôle pour suivre vos mesures de mitigation.</div>
+                    <button class="btn btn-secondary" onclick="addNewControl()">+ Ajouter un contrôle</button>
+                </div>
+            `;
+            return;
+        }
+
+        const typeMap = {
+            'preventif': 'Préventif',
+            'detectif': 'Détectif'
+        };
+
+        const statusMap = {
+            'actif': 'Actif',
+            'en-mise-en-place': 'En mise en place',
+            'en-revision': 'En cours de révision',
+            'obsolete': 'Obsolète'
+        };
+
         container.innerHTML = this.controls.map(control => {
-            // Récupérer les risques couverts
-            const coveredRisks = control.risks ? this.risks.filter(risk => 
-                control.risks.includes(risk.id)
-            ).map(risk => risk.description.substring(0, 50) + '...').join(', ') : 'Aucun risque associé';
-            
-            // Mapper les valeurs d'efficacité
-            const effectivenessMap = {
-                'forte': 'Forte',
-                'moyenne': 'Moyenne', 
-                'faible': 'Faible',
-                'high': 'Forte',
-                'medium': 'Moyenne',
-                'low': 'Faible'
-            };
-            
-            // Mapper les statuts
-            const statusMap = {
-                'actif': 'Actif',
-                'en-mise-en-place': 'En mise en place',
-                'en-revision': 'En cours de révision',
-                'obsolete': 'Obsolète'
-            };
-            
+            const controlName = control.name || 'Contrôle sans nom';
+            const typeLabel = typeMap[control.type] || (control.type ? control.type : 'Non défini');
+            const typeClass = control.type ? control.type : 'type-undefined';
+            const ownerLabel = control.owner || '';
+            const statusLabel = control.status ? (statusMap[control.status] || control.status) : '';
+
             return `
-                <div class="control-item" data-control-id="${control.id}">
-                    <div class="control-actions">
-                        <button class="control-action-btn edit" data-control-id="${control.id}" title="Modifier">
-                            ✏️
-                        </button>
-                        <button class="control-action-btn delete" onclick="deleteControl(${control.id})" title="Supprimer">
-                            🗑️
-                        </button>
+                <div class="controls-table-row" data-control-id="${control.id}">
+                    <div class="controls-table-cell control-name-cell">
+                        <div class="control-name" title="${controlName}">${controlName}</div>
                     </div>
-                    
-                    <div class="control-header">
-                        <div>
-                            <div class="control-name">${control.name || 'Contrôle sans nom'}</div>
-                            <div class="control-type-badge ${control.type || 'preventif'}">
-                                ${control.type === 'preventif' ? 'Préventif' : 'Détectif'}
-                            </div>
-                        </div>
-                        ${control.status ? `<span class="control-status-badge ${control.status}">${statusMap[control.status] || control.status}</span>` : ''}
+                    <div class="controls-table-cell control-type-cell">
+                        <span class="control-type-badge ${typeClass}">${typeLabel}</span>
                     </div>
-                    
-                    ${control.description ? `<div style="margin: 10px 0; color: #666; font-size: 0.9em;">${control.description}</div>` : ''}
-                    
-                    <div style="margin: 10px 0; font-size: 0.85em; color: #7f8c8d;">
-                        <strong>Risques couverts:</strong> ${coveredRisks}
+                    <div class="controls-table-cell control-owner-cell">
+                        ${ownerLabel ? `<span class="control-owner">${ownerLabel}</span>` : `<span class="text-placeholder">Non défini</span>`}
                     </div>
-                    
-                    <div class="control-meta">
-                        ${control.owner ? `
-                            <div class="control-meta-item">
-                                <div class="control-meta-label">Propriétaire</div>
-                                <div class="control-meta-value">${control.owner}</div>
-                            </div>
-                        ` : ''}
-                        ${control.frequency ? `
-                            <div class="control-meta-item">
-                                <div class="control-meta-label">Fréquence</div>
-                                <div class="control-meta-value">${control.frequency}</div>
-                            </div>
-                        ` : ''}
-                        ${control.mode ? `
-                            <div class="control-meta-item">
-                                <div class="control-meta-label">Mode</div>
-                                <div class="control-meta-value">${control.mode}</div>
-                            </div>
-                        ` : ''}
-                        <div class="control-meta-item">
-                            <div class="control-meta-label">Efficacité</div>
-                            <div class="control-meta-value">${effectivenessMap[control.effectiveness] || 'Non définie'}</div>
-                        </div>
+                    <div class="controls-table-cell control-status-cell">
+                        ${statusLabel ? `<span class="control-status-badge ${control.status}">${statusLabel}</span>` : `<span class="text-placeholder">Non défini</span>`}
+                    </div>
+                    <div class="controls-table-cell controls-table-actions">
+                        <button class="action-btn" onclick="editControl(${control.id})" title="Modifier">✏️</button>
+                        <button class="action-btn" onclick="deleteControl(${control.id})" title="Supprimer">🗑️</button>
                     </div>
                 </div>
             `;


### PR DESCRIPTION
## Summary
- restructure the controls tab markup to present the list as a table with dedicated columns for the required fields
- style the new controls list with responsive table-like rows, placeholders, and an empty-state message while reusing the risk action button design
- update the controls renderer to output the simplified row content and provide graceful fallbacks for missing values

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ca6283aa58832e8ff82c0ff0383758