### PR TITLE
Ajout des filtres de statut et recherche pour les plans d'action

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -367,6 +367,18 @@
                 <div class="content-area">
                     <div class="controls-section">
                         <div class="form-section-title">Plans d'actions</div>
+                        <div class="filters-bar">
+                            <div class="filter-group">
+                                <label class="filter-label" for="actionPlansStatusFilter">Statut</label>
+                                <select id="actionPlansStatusFilter" class="filter-select" data-action-plan-filter="status" onchange="applyActionPlanFilters('status', this.value, this)">
+                                    <option value="">Tous les statuts</option>
+                                </select>
+                            </div>
+                            <div class="search-box filter-group">
+                                <label class="filter-label" for="actionPlansSearchInput">Recherche</label>
+                                <input type="search" id="actionPlansSearchInput" class="search-input" placeholder="Rechercher un plan d'action" data-action-plan-filter="search" oninput="searchActionPlans(this.value, this)">
+                            </div>
+                        </div>
                         <div class="controls-grid" id="actionPlansList">
                             <!-- Populated by JavaScript -->
                         </div>
@@ -584,10 +596,6 @@
                                 <label class="form-label" for="planStatus">Statut</label>
                                 <select class="form-select" id="planStatus" name="status">
                                     <option value="">Sélectionner...</option>
-                                    <option value="brouillon">Brouillon</option>
-                                    <option value="a-demarrer">À démarrer</option>
-                                    <option value="en-cours">En cours</option>
-                                    <option value="termine">Terminé</option>
                                 </select>
                             </div>
                             <div class="form-group" style="grid-column: 1 / -1;">

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -126,6 +126,64 @@ function searchControls(searchTerm, sourceElement) {
 }
 window.searchControls = searchControls;
 
+function syncActionPlanFilterWidgets(filterKey, value, sourceElement) {
+    const normalizedKey = typeof filterKey === 'string' ? filterKey.trim() : '';
+    if (!normalizedKey) return;
+
+    const normalizedValue = value == null ? '' : String(value);
+
+    document.querySelectorAll(`[data-action-plan-filter="${normalizedKey}"]`).forEach(element => {
+        if (element === sourceElement) {
+            return;
+        }
+
+        if (!('value' in element)) {
+            return;
+        }
+
+        if (element.value !== normalizedValue) {
+            element.value = normalizedValue;
+        }
+    });
+}
+
+function applyActionPlanFilters(filterKey, value, sourceElement) {
+    if (!window.rms) return;
+
+    const normalizedKey = typeof filterKey === 'string' ? filterKey.trim() : '';
+    if (!normalizedKey) return;
+
+    const normalizedValue = value == null ? '' : String(value);
+
+    if (!rms.actionPlanFilters) {
+        rms.actionPlanFilters = { status: '', search: '' };
+    }
+
+    rms.actionPlanFilters[normalizedKey] = normalizedValue;
+
+    syncActionPlanFilterWidgets(normalizedKey, normalizedValue, sourceElement);
+
+    rms.updateActionPlansList();
+}
+window.applyActionPlanFilters = applyActionPlanFilters;
+
+function searchActionPlans(searchTerm, sourceElement) {
+    if (!window.rms) return;
+
+    const normalizedValue = searchTerm == null ? '' : String(searchTerm);
+
+    if (!rms.actionPlanFilters) {
+        rms.actionPlanFilters = { status: '', search: '' };
+    }
+
+    rms.actionPlanFilters.search = normalizedValue;
+
+    syncActionPlanFilterWidgets('search', normalizedValue, sourceElement);
+
+    rms.updateActionPlansList();
+}
+window.searchActionPlans = searchActionPlans;
+
 var lastRiskData = null;
 var selectedControlsForRisk = [];
 var controlFilterQueryForRisk = '';


### PR DESCRIPTION
## Summary
- ajouter une barre de filtres (statut et recherche) pour la liste des plans d'actions dans l'interface
- centraliser les statuts de plan dans la configuration et filtrer le rendu via `getFilteredActionPlans`
- exposer des handlers UI pour appliquer/synchroniser les filtres et relancer le rafraîchissement

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca6c6f1478832ebcb9370c60812670