### PR TITLE
Refonte de la liste des plans d'actions

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -369,18 +369,39 @@
                         <div class="form-section-title">Plans d'actions</div>
                         <div class="filters-bar">
                             <div class="filter-group">
+                                <label class="filter-label" for="actionPlansNameFilter">Nom</label>
+                                <input type="search" id="actionPlansNameFilter" class="search-input" placeholder="Rechercher par nom" data-action-plan-filter="name" oninput="applyActionPlanFilters('name', this.value, this)">
+                            </div>
+                            <div class="filter-group">
+                                <label class="filter-label" for="actionPlansOwnerFilter">Propriétaire</label>
+                                <input type="search" id="actionPlansOwnerFilter" class="search-input" placeholder="Filtrer par propriétaire" data-action-plan-filter="owner" oninput="applyActionPlanFilters('owner', this.value, this)">
+                            </div>
+                            <div class="filter-group">
                                 <label class="filter-label" for="actionPlansStatusFilter">Statut</label>
                                 <select id="actionPlansStatusFilter" class="filter-select" data-action-plan-filter="status" onchange="applyActionPlanFilters('status', this.value, this)">
                                     <option value="">Tous les statuts</option>
                                 </select>
                             </div>
-                            <div class="search-box filter-group">
-                                <label class="filter-label" for="actionPlansSearchInput">Recherche</label>
-                                <input type="search" id="actionPlansSearchInput" class="search-input" placeholder="Rechercher un plan d'action" data-action-plan-filter="search" oninput="searchActionPlans(this.value, this)">
+                            <div class="filter-group">
+                                <label class="filter-label" for="actionPlansDueDateSort">Échéance</label>
+                                <select id="actionPlansDueDateSort" class="filter-select" data-action-plan-filter="dueDateOrder" onchange="applyActionPlanFilters('dueDateOrder', this.value, this)">
+                                    <option value="">Sans tri</option>
+                                    <option value="asc">Ordre chronologique</option>
+                                    <option value="desc">Ordre antéchronologique</option>
+                                </select>
                             </div>
                         </div>
-                        <div class="controls-grid" id="actionPlansList">
-                            <!-- Populated by JavaScript -->
+                        <div class="controls-table">
+                            <div class="controls-table-header">
+                                <div>Nom du plan d'action</div>
+                                <div>Propriétaire</div>
+                                <div>Échéance</div>
+                                <div>Statut</div>
+                                <div class="controls-table-actions">Actions</div>
+                            </div>
+                            <div class="controls-table-body" id="actionPlansList">
+                                <!-- Populated by JavaScript -->
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1267,6 +1267,26 @@ tbody tr:hover {
     color: #721c24;
 }
 
+.control-status-badge.brouillon {
+    background: #e2e3e5;
+    color: #383d41;
+}
+
+.control-status-badge.a-demarrer {
+    background: #d1ecf1;
+    color: #0c5460;
+}
+
+.control-status-badge.en-cours {
+    background: #fff3cd;
+    color: #856404;
+}
+
+.control-status-badge.termine {
+    background: #d4edda;
+    color: #155724;
+}
+
 .control-actions {
     position: absolute;
     top: 15px;
@@ -1509,6 +1529,12 @@ tbody tr:hover {
 .control-owner-cell .control-owner {
     font-weight: 500;
     color: #34495e;
+}
+
+.control-due-date-cell .control-due-date {
+    font-weight: 500;
+    color: #34495e;
+    white-space: nowrap;
 }
 
 .control-status-cell .control-status-badge {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -155,8 +155,12 @@ function applyActionPlanFilters(filterKey, value, sourceElement) {
 
     const normalizedValue = value == null ? '' : String(value);
 
+    const defaultFilters = { status: '', name: '', owner: '', dueDateOrder: '' };
+
     if (!rms.actionPlanFilters) {
-        rms.actionPlanFilters = { status: '', search: '' };
+        rms.actionPlanFilters = { ...defaultFilters };
+    } else {
+        rms.actionPlanFilters = { ...defaultFilters, ...rms.actionPlanFilters };
     }
 
     rms.actionPlanFilters[normalizedKey] = normalizedValue;
@@ -168,19 +172,7 @@ function applyActionPlanFilters(filterKey, value, sourceElement) {
 window.applyActionPlanFilters = applyActionPlanFilters;
 
 function searchActionPlans(searchTerm, sourceElement) {
-    if (!window.rms) return;
-
-    const normalizedValue = searchTerm == null ? '' : String(searchTerm);
-
-    if (!rms.actionPlanFilters) {
-        rms.actionPlanFilters = { status: '', search: '' };
-    }
-
-    rms.actionPlanFilters.search = normalizedValue;
-
-    syncActionPlanFilterWidgets('search', normalizedValue, sourceElement);
-
-    rms.updateActionPlansList();
+    applyActionPlanFilters('name', searchTerm, sourceElement);
 }
 window.searchActionPlans = searchActionPlans;
 


### PR DESCRIPTION
## Summary
- transformer l’affichage des plans d’actions en tableau aligné sur la liste des contrôles avec les colonnes demandées
- ajouter des filtres dédiés (nom, propriétaire, statut) et un tri par échéance chronologique/antéchronologique
- harmoniser le style avec de nouveaux badges de statut et un affichage dédié des dates d’échéance

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68ca70407540832e8cd17a07b0b94ad9