### PR TITLE
Add dynamic owner suggestions to action plan modal

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -607,7 +607,8 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label class="form-label" for="planOwner">Propriétaire</label>
-                                <input class="form-input" type="text" id="planOwner" name="owner" placeholder="Personne responsable du suivi">
+                                <input class="form-input" type="text" id="planOwner" name="owner" placeholder="Personne responsable du suivi" list="planOwnerSuggestions">
+                                <datalist id="planOwnerSuggestions"></datalist>
                             </div>
                             <div class="form-group">
                                 <label class="form-label" for="planDueDate">Échéance</label>

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -540,6 +540,29 @@ function confirmActionPlanSelection() {
 }
 window.confirmActionPlanSelection = confirmActionPlanSelection;
 
+function populatePlanOwnerSuggestions() {
+    const datalist = document.getElementById('planOwnerSuggestions');
+    if (!datalist) return;
+
+    datalist.innerHTML = '';
+
+    if (!window.rms || !Array.isArray(rms.actionPlans)) {
+        return;
+    }
+
+    const uniqueOwners = Array.from(new Set(
+        rms.actionPlans
+            .map(plan => (plan && typeof plan.owner === 'string') ? plan.owner.trim() : '')
+            .filter(owner => owner)
+    ));
+
+    uniqueOwners.forEach(owner => {
+        const option = document.createElement('option');
+        option.value = owner;
+        datalist.appendChild(option);
+    });
+}
+
 function addNewActionPlan() {
     currentEditingActionPlanId = null;
     const form = document.getElementById('actionPlanForm');
@@ -557,6 +580,7 @@ function addNewActionPlan() {
         updateSelectedRisksForPlanDisplay();
     }
     document.getElementById('actionPlanModalTitle').textContent = "Nouveau Plan d'action";
+    populatePlanOwnerSuggestions();
     document.getElementById('actionPlanModal').classList.add('show');
 }
 window.addNewActionPlan = addNewActionPlan;
@@ -576,6 +600,7 @@ function editActionPlan(planId) {
         updateSelectedRisksForPlanDisplay();
     }
     document.getElementById('actionPlanModalTitle').textContent = "Modifier le Plan d'action";
+    populatePlanOwnerSuggestions();
     document.getElementById('actionPlanModal').classList.add('show');
 }
 window.editActionPlan = editActionPlan;
@@ -647,6 +672,7 @@ function saveActionPlan() {
     lastActionPlanData = { ...planData };
     rms.saveData();
     rms.renderAll();
+    populatePlanOwnerSuggestions();
     closeActionPlanModal();
 }
 window.saveActionPlan = saveActionPlan;


### PR DESCRIPTION
## Summary
- add a datalist to the action plan owner input field
- populate the datalist with unique owners from existing action plans when the modal opens or a plan is saved

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca734c40b4832eb16a085253fb6203