### PR TITLE
Ajoute l'auto-complétion du propriétaire pour les contrôles

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -549,7 +549,8 @@
 
                             <div class="form-group">
                                 <label class="form-label required" for="controlOwner">Propriétaire</label>
-                                <input class="form-input" type="text" id="controlOwner" name="owner" required placeholder="Nom ou fonction responsable">
+                                <input class="form-input" type="text" id="controlOwner" name="owner" required placeholder="Nom ou fonction responsable" list="controlOwnerSuggestions">
+                                <datalist id="controlOwnerSuggestions"></datalist>
                             </div>
 
                             <div class="form-group">

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -205,6 +205,25 @@ function applyPatch() {
       let riskFilterQueryForControl = '';
       let lastControlData = null;
 
+      function populateControlOwnerSuggestions() {
+        const datalist = document.getElementById('controlOwnerSuggestions');
+        if (!datalist) return;
+
+        datalist.innerHTML = '';
+
+        const uniqueOwners = Array.from(new Set(
+          (state.controls || [])
+            .map(ctrl => (ctrl && typeof ctrl.owner === 'string') ? ctrl.owner.trim() : '')
+            .filter(owner => owner)
+        ));
+
+        uniqueOwners.forEach(owner => {
+          const option = document.createElement('option');
+          option.value = owner;
+          datalist.appendChild(option);
+        });
+      }
+
       window.addNewControl = function() {
         currentEditingControlId = null;
         const form = document.getElementById('controlForm');
@@ -226,6 +245,7 @@ function applyPatch() {
 
         document.getElementById('controlModalTitle').textContent = 'Nouveau Contrôle';
         updateSelectedRisksDisplay();
+        populateControlOwnerSuggestions();
         document.getElementById('controlModal').classList.add('show');
       };
 
@@ -250,6 +270,7 @@ function applyPatch() {
 
         document.getElementById('controlModalTitle').textContent = 'Modifier le Contrôle';
         updateSelectedRisksDisplay();
+        populateControlOwnerSuggestions();
         document.getElementById('controlModal').classList.add('show');
       };
 
@@ -417,6 +438,7 @@ function applyPatch() {
 
         state.save("contrôle");
         state.renderAll();
+        populateControlOwnerSuggestions();
         closeControlModal();
       };
 


### PR DESCRIPTION
## Summary
- active l'auto-complétion du propriétaire des contrôles avec un datalist dédié
- alimente les suggestions avec les propriétaires déjà saisis lors de l'ouverture et de l'enregistrement d'un contrôle

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca9022bdc0832ea63d88447c83416c