### PR TITLE
Prioritize configuration label inputs

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2023,6 +2023,41 @@ tbody tr:hover {
     font-size: 0.9em;
 }
 
+.config-input-label {
+    border-color: rgba(52, 152, 219, 0.7);
+    background: #eef6ff;
+    color: #1f2a44;
+    font-weight: 600;
+    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.12);
+}
+
+.config-input-label::placeholder {
+    color: rgba(31, 42, 68, 0.65);
+    font-weight: 500;
+}
+
+.config-input-label:focus-visible {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.22);
+}
+
+.config-input-value {
+    background: #f6f8fb;
+    color: #5f6c7b;
+    border-color: #c7d1e2;
+}
+
+.config-input-value::placeholder {
+    color: #7b8aa0;
+}
+
+.config-input-value:focus-visible {
+    outline: none;
+    border-color: #a7b4c8;
+    box-shadow: 0 0 0 2px rgba(167, 180, 200, 0.25);
+}
+
 .config-add button {
     background: var(--primary-color);
     color: #fff;

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -644,15 +644,17 @@ class RiskManagementSystem {
             const addContainer = document.createElement('div');
             addContainer.className = 'config-add';
 
-            const valueInput = document.createElement('input');
-            valueInput.type = 'text';
-            valueInput.id = `input-${key}-value`;
-            valueInput.placeholder = 'valeur';
-
             const labelInput = document.createElement('input');
             labelInput.type = 'text';
             labelInput.id = `input-${key}-label`;
-            labelInput.placeholder = 'libellé';
+            labelInput.placeholder = 'Libellé à saisir';
+            labelInput.classList.add('config-input-label');
+
+            const valueInput = document.createElement('input');
+            valueInput.type = 'text';
+            valueInput.id = `input-${key}-value`;
+            valueInput.placeholder = 'Valeur auto-générée';
+            valueInput.classList.add('config-input-value');
 
             const addButton = document.createElement('button');
             addButton.type = 'button';
@@ -661,8 +663,8 @@ class RiskManagementSystem {
                 this.addConfigOption(key);
             });
 
-            addContainer.appendChild(valueInput);
             addContainer.appendChild(labelInput);
+            addContainer.appendChild(valueInput);
             addContainer.appendChild(addButton);
 
             body.appendChild(list);
@@ -794,17 +796,17 @@ class RiskManagementSystem {
                 const form = document.createElement('div');
                 form.className = 'config-edit-form';
 
-                const valueInput = document.createElement('input');
-                valueInput.type = 'text';
-                valueInput.value = opt.value;
-                valueInput.placeholder = 'valeur';
-                valueInput.className = 'config-edit-input';
-
                 const labelInput = document.createElement('input');
                 labelInput.type = 'text';
                 labelInput.value = opt.label;
-                labelInput.placeholder = 'libellé';
-                labelInput.className = 'config-edit-input';
+                labelInput.placeholder = 'Libellé à saisir';
+                labelInput.className = 'config-edit-input config-input-label';
+
+                const valueInput = document.createElement('input');
+                valueInput.type = 'text';
+                valueInput.value = opt.value;
+                valueInput.placeholder = 'Valeur auto-générée';
+                valueInput.className = 'config-edit-input config-input-value';
 
                 const actions = document.createElement('div');
                 actions.className = 'config-item-actions';
@@ -831,8 +833,8 @@ class RiskManagementSystem {
                 actions.appendChild(saveButton);
                 actions.appendChild(cancelButton);
 
-                form.appendChild(valueInput);
                 form.appendChild(labelInput);
+                form.appendChild(valueInput);
                 form.appendChild(actions);
                 this.setupAutoValueSync(labelInput, valueInput);
                 listItem.appendChild(form);
@@ -992,15 +994,17 @@ class RiskManagementSystem {
             const addContainer = document.createElement('div');
             addContainer.className = 'config-add';
 
-            const valueInput = document.createElement('input');
-            valueInput.type = 'text';
-            valueInput.id = `input-sub-${procId}-value`;
-            valueInput.placeholder = 'valeur';
-
             const labelInput = document.createElement('input');
             labelInput.type = 'text';
             labelInput.id = `input-sub-${procId}-label`;
-            labelInput.placeholder = 'libellé';
+            labelInput.placeholder = 'Libellé à saisir';
+            labelInput.classList.add('config-input-label');
+
+            const valueInput = document.createElement('input');
+            valueInput.type = 'text';
+            valueInput.id = `input-sub-${procId}-value`;
+            valueInput.placeholder = 'Valeur auto-générée';
+            valueInput.classList.add('config-input-value');
 
             const addButton = document.createElement('button');
             addButton.type = 'button';
@@ -1013,8 +1017,8 @@ class RiskManagementSystem {
                 }
             });
 
-            addContainer.appendChild(valueInput);
             addContainer.appendChild(labelInput);
+            addContainer.appendChild(valueInput);
             addContainer.appendChild(addButton);
 
             body.appendChild(list);
@@ -1082,17 +1086,17 @@ class RiskManagementSystem {
                     const form = document.createElement('div');
                     form.className = 'config-edit-form';
 
-                    const valueInput = document.createElement('input');
-                    valueInput.type = 'text';
-                    valueInput.value = sp.value;
-                    valueInput.placeholder = 'valeur';
-                    valueInput.className = 'config-edit-input';
-
                     const labelInput = document.createElement('input');
                     labelInput.type = 'text';
                     labelInput.value = sp.label;
-                    labelInput.placeholder = 'libellé';
-                    labelInput.className = 'config-edit-input';
+                    labelInput.placeholder = 'Libellé à saisir';
+                    labelInput.className = 'config-edit-input config-input-label';
+
+                    const valueInput = document.createElement('input');
+                    valueInput.type = 'text';
+                    valueInput.value = sp.value;
+                    valueInput.placeholder = 'Valeur auto-générée';
+                    valueInput.className = 'config-edit-input config-input-value';
 
                     const actions = document.createElement('div');
                     actions.className = 'config-item-actions';
@@ -1119,8 +1123,8 @@ class RiskManagementSystem {
                     actions.appendChild(saveButton);
                     actions.appendChild(cancelButton);
 
-                    form.appendChild(valueInput);
                     form.appendChild(labelInput);
+                    form.appendChild(valueInput);
                     form.appendChild(actions);
                     this.setupAutoValueSync(labelInput, valueInput);
                     listItem.appendChild(form);


### PR DESCRIPTION
## Summary
- reorder configuration form inputs so the user-facing label precedes the auto-generated value for both add and edit flows
- differentiate placeholders and apply dedicated classes to label/value inputs to highlight manual entry fields
- style configuration label inputs for stronger emphasis and soften the appearance of auto-generated value fields

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca91415140832eb98fb69893abe1da