### PR TITLE
Synchronize configuration accordions

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1918,7 +1918,7 @@ tbody tr:hover {
 }
 
 .config-accordion-item.open .config-accordion-body {
-    padding: 16px 20px 20px;
+    padding: 16px 20px 28px;
 }
 
 .config-accordion-nested {
@@ -1940,7 +1940,7 @@ tbody tr:hover {
 }
 
 .config-accordion-nested .config-accordion-item.open .config-accordion-body {
-    padding: 12px 16px 16px;
+    padding: 12px 16px 20px;
 }
 
 .config-accordion-body .config-list {

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -712,6 +712,24 @@ class RiskManagementSystem {
             return { setOpen: () => {} };
         }
 
+        const findDirectChild = (element, selector) => {
+            return Array.from(element.children).find(child => child.matches(selector));
+        };
+
+        const closeAccordionItem = (targetItem) => {
+            const targetHeader = findDirectChild(targetItem, '.config-accordion-header');
+            const targetBody = findDirectChild(targetItem, '.config-accordion-body');
+
+            targetItem.classList.remove('open');
+            if (targetHeader) {
+                targetHeader.setAttribute('aria-expanded', 'false');
+            }
+            if (targetBody) {
+                targetBody.setAttribute('aria-hidden', 'true');
+                targetBody.style.maxHeight = '0px';
+            }
+        };
+
         const setState = (open) => {
             if (open) {
                 item.classList.add('open');
@@ -731,6 +749,14 @@ class RiskManagementSystem {
 
         headerButton.addEventListener('click', () => {
             const willOpen = !item.classList.contains('open');
+            if (willOpen) {
+                const parent = item.parentElement;
+                if (parent instanceof HTMLElement) {
+                    Array.from(parent.children)
+                        .filter(child => child !== item && child instanceof HTMLElement && child.classList.contains('config-accordion-item') && child.classList.contains('open'))
+                        .forEach(openItem => closeAccordionItem(openItem));
+                }
+            }
             setState(willOpen);
         });
 


### PR DESCRIPTION
## Summary
- ensure configuration accordions close their siblings when a new section is opened
- add extra breathing room below add-item inputs so they are fully visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca95718270832ebe2a7d3d4f97a6b9