### PR TITLE
Add snapshot export/import support

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -504,8 +504,25 @@
             <div class="main-content">
                 <div class="toolbar">
                     <div class="toolbar-title">Configuration</div>
+                    <div class="toolbar-actions">
+                        <button class="btn btn-outline" onclick="saveSnapshotToFile()">
+                            💾 Exporter la sauvegarde
+                        </button>
+                        <button class="btn btn-primary" onclick="loadSnapshotFromFile()">
+                            📂 Importer une sauvegarde
+                        </button>
+                    </div>
                 </div>
-                <div class="content-area" id="configurationContainer"></div>
+                <div class="content-area">
+                    <div class="config-helper" style="margin-bottom: 1.5rem;">
+                        <p>
+                            💡 Exportez un instantané pour le transférer manuellement vers un autre navigateur puis
+                            importez le fichier <code>rms-sauvegarde.json</code> afin de restaurer l'état complet de votre
+                            cartographie.
+                        </p>
+                    </div>
+                    <div id="configurationContainer"></div>
+                </div>
             </div>
     </div>
     </div>


### PR DESCRIPTION
## Summary
- add snapshot utilities and configuration normalization inside the core RMS logic
- export full snapshots to `rms-sauvegarde.json` and support loading them back into the app
- wire snapshot import/export controls into the integrations helpers and configuration tab UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9ad0e988832e86ddfeb4e41f5838