### PR TITLE
Remove risk owner information

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -143,7 +143,6 @@
                                     <th>Risque</th>
                                     <th>Processus</th>
                                     <th>Niveau</th>
-                                    <th>Responsable</th>
                                     <th>Actions</th>
                                 </tr>
                             </thead>
@@ -313,7 +312,6 @@
                                     <th>Score Net</th>
                                     <th>Score Final</th>
                                     <th>Statut</th>
-                                    <th>Responsable</th>
                                     <th>Actions</th>
                                 </tr>
                             </thead>

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -82,7 +82,6 @@ class RiskManagementSystem {
                 probNet: 2, impactNet: 3,
                 probPost: 1, impactPost: 2,
                 statut: "a-valider",
-                responsable: "Dr. Martin",
                 dateCreation: "2024-01-15",
                 controls: [1, 2]
             },
@@ -98,7 +97,6 @@ class RiskManagementSystem {
                 probNet: 2, impactNet: 2,
                 probPost: 1, impactPost: 2,
                 statut: "validé",
-                responsable: "M. Durand",
                 dateCreation: "2024-01-20",
                 controls: [3]
             },
@@ -114,7 +112,6 @@ class RiskManagementSystem {
                 probNet: 2, impactNet: 3,  // Même position que risque 1
                 probPost: 1, impactPost: 2,
                 statut: "brouillon",
-                responsable: "Mme. Leroy",
                 dateCreation: "2024-02-01",
                 controls: [1, 4]
             },
@@ -130,7 +127,6 @@ class RiskManagementSystem {
                 probNet: 2, impactNet: 3,  // Même position que risques 1 et 3
                 probPost: 1, impactPost: 1,
                 statut: "a-valider",
-                responsable: "M. Bernard",
                 dateCreation: "2024-01-10",
                 controls: [2, 3]
             },
@@ -146,7 +142,6 @@ class RiskManagementSystem {
                 probNet: 1, impactNet: 2,
                 probPost: 1, impactPost: 1,  // Même position que risque 4
                 statut: "validé",
-                responsable: "Mme. Petit",
                 dateCreation: "2024-01-25",
                 controls: [1]
             },
@@ -162,7 +157,6 @@ class RiskManagementSystem {
                 probNet: 1, impactNet: 3,
                 probPost: 1, impactPost: 2,
                 statut: "brouillon",
-                responsable: "M. Moreau",
                 dateCreation: "2024-02-05",
                 controls: [2, 3, 4]
             },
@@ -178,7 +172,6 @@ class RiskManagementSystem {
                 probNet: 2, impactNet: 2,
                 probPost: 1, impactPost: 1,  // Même position que risques 4 et 5
                 statut: "a-valider",
-                responsable: "Mme. Dubois",
                 dateCreation: "2024-02-10",
                 controls: [1, 2]
             },
@@ -194,7 +187,6 @@ class RiskManagementSystem {
                 probNet: 1, impactNet: 2,
                 probPost: 1, impactPost: 1,  // Même position que risques 4, 5 et 7
                 statut: "archive",
-                responsable: "Me. Lambert",
                 dateCreation: "2024-01-30",
                 controls: [3, 4]
             }
@@ -1578,7 +1570,7 @@ class RiskManagementSystem {
                         <span class="risk-item-score ${scoreClass}">${score}</span>
                     </div>
                     <div class="risk-item-meta">
-                        ${risk.processus}${sp} • ${risk.responsable}
+                        ${risk.processus}${sp}
                     </div>
                 </div>
             `;
@@ -1618,7 +1610,7 @@ class RiskManagementSystem {
         if (highRisks.length === 0) {
             tbody.innerHTML = `
                 <tr>
-                    <td colspan="6" class="table-empty">Aucune alerte récente</td>
+                    <td colspan="5" class="table-empty">Aucune alerte récente</td>
                 </tr>
             `;
             return;
@@ -1634,7 +1626,6 @@ class RiskManagementSystem {
             const formattedDate = parsedDate && !isNaN(parsedDate) ? parsedDate.toLocaleDateString('fr-FR') : '-';
             const description = risk.description || 'Sans description';
             const process = risk.processus || '-';
-            const owner = risk.responsable || '-';
 
             return `
                 <tr>
@@ -1642,7 +1633,6 @@ class RiskManagementSystem {
                     <td>${description}</td>
                     <td>${process}</td>
                     <td><span class="table-badge ${badgeClass}">${levelLabel}</span></td>
-                    <td>${owner}</td>
                     <td class="table-actions-cell">
                         <button class="action-btn" onclick="rms.selectRisk(${JSON.stringify(risk.id)})">👁️</button>
                         <button class="action-btn" onclick="rms.editRisk(${JSON.stringify(risk.id)})">✏️</button>
@@ -1696,7 +1686,6 @@ class RiskManagementSystem {
                 <td>${risk.probNet * risk.impactNet}</td>
                 <td>${risk.probPost * risk.impactPost}</td>
                 <td><span class="table-badge badge-${risk.statut === 'validé' ? 'success' : risk.statut === 'archive' ? 'danger' : 'warning'}">${risk.statut}</span></td>
-                <td>${risk.responsable}</td>
                 <td class="table-actions-cell">
                     <button class="action-btn" onclick="rms.editRisk(${JSON.stringify(risk.id)})">✏️</button>
                     <button class="action-btn" onclick="rms.deleteRisk(${JSON.stringify(risk.id)})">🗑️</button>

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -350,7 +350,6 @@ function saveRisk() {
         impactNet: parseInt(document.getElementById('impactNet').value),
         probPost: parseInt(document.getElementById('probPost').value),
         impactPost: parseInt(document.getElementById('impactPost').value),
-        responsable: 'Marie Dupont',
         controls: [...selectedControlsForRisk],
         actionPlans: [...selectedActionPlansForRisk]
     };


### PR DESCRIPTION
## Summary
- remove default risk owner metadata and stop rendering the responsible person in matrices, dashboards, and lists
- drop the "Responsable" column from the dashboard and risk tables to align with the simplified data model
- stop assigning a placeholder owner when creating or editing a risk

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca9d6492f0832e8235b6fa0f89b01a