### PR TITLE
Remove automatic autosave mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Application monopage de cartographie des risques de corruption. Elle fournit un 
 ## Données & persistance
 
 - Toutes les données sont stockées côté navigateur via `localStorage` (`rms_risks`, `rms_controls`, `rms_actionPlans`, `rms_history`, `rms_config`).
-- Une sauvegarde automatique est effectuée toutes les 30 secondes et la date de dernière sauvegarde est affichée dans l'en-tête.
+- Les modifications sont enregistrées immédiatement dans le navigateur et la date de dernière sauvegarde est affichée dans l'en-tête.
 - Les exports sont effectués côté client : `exportRisks()` produit un CSV et `exportDashboard()` télécharge un JSON avec le registre des risques, les contrôles ainsi que des métadonnées (`exportDate`, `exportedBy`).
 - L'import accepte des fichiers CSV (colonnes libres, mappées automatiquement) ou JSON (structure `{ risks, controls, history }`). Chaque import ajoute un événement dans l'historique.
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -50,9 +50,6 @@ class RiskManagementSystem {
         }
         this.saveData();
         this.updateLastSaveTime();
-
-        // Auto-save every 30 seconds
-        setInterval(() => this.autoSave(), 30000);
     }
 
     renderAll() {
@@ -383,6 +380,7 @@ class RiskManagementSystem {
 
     saveConfig() {
         localStorage.setItem('rms_config', JSON.stringify(this.config));
+        this.updateLastSaveTime();
     }
 
     ensureConfigStructure(defaultConfig = this.getDefaultConfig()) {
@@ -1346,6 +1344,7 @@ class RiskManagementSystem {
         localStorage.setItem('rms_controls', JSON.stringify(this.controls));
         localStorage.setItem('rms_actionPlans', JSON.stringify(this.actionPlans));
         localStorage.setItem('rms_history', JSON.stringify(this.history));
+        this.updateLastSaveTime();
     }
 
     loadData(key) {
@@ -1353,16 +1352,13 @@ class RiskManagementSystem {
         return data ? JSON.parse(data) : null;
     }
 
-    autoSave() {
-        this.saveData();
-        this.updateLastSaveTime();
-        showNotification('info', 'Sauvegarde automatique effectuée');
-    }
-
     updateLastSaveTime() {
         const now = new Date();
         const timeStr = now.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
-        document.getElementById('lastSaveTime').textContent = timeStr;
+        const lastSaveElement = document.getElementById('lastSaveTime');
+        if (lastSaveElement) {
+            lastSaveElement.textContent = timeStr;
+        }
     }
 
     // Matrix functions


### PR DESCRIPTION
## Summary
- remove the periodic autosave interval and associated notification
- refresh the "dernière sauvegarde" indicator whenever data or configuration is persisted
- document the new persistence behaviour in the README

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca9e9b0120832e9d51b3486b607420