### PR TITLE
Replace header shield with LFB logo

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -15,10 +15,11 @@
         <!-- Header amélioré -->
         <div class="header">
             <div class="header-left">
-                <h1>🛡️ Cartographie des Risques Corruption</h1>
+                <h1>Cartographie des Risques Corruption</h1>
                 <p>Conformité Loi Sapin 2 - Système de Management Anti-Corruption</p>
             </div>
             <div class="header-right">
+                <img src="assets/img/lfb-logo.svg" alt="LFB Biomanufacturing" class="header-logo">
                 <div class="user-info">
                     <div class="user-name">Marie Dupont</div>
                     <div class="user-role">Responsable Conformité</div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -60,6 +60,13 @@ body {
     gap: 15px;
 }
 
+.header-logo {
+    height: 60px;
+    width: auto;
+    max-width: 220px;
+    display: block;
+}
+
 .user-info {
     text-align: right;
     padding-right: 15px;
@@ -1773,16 +1780,29 @@ tbody tr:hover {
     .container {
         padding: 10px;
     }
-    
+
     .header {
         flex-direction: column;
         text-align: center;
         gap: 15px;
     }
-    
+
     .header-right {
         width: 100%;
         justify-content: center;
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    .user-info {
+        padding-right: 0;
+        border-right: none;
+        padding-bottom: 10px;
+        border-bottom: 2px solid #ecf0f1;
+    }
+
+    .header-logo {
+        height: 50px;
     }
     
     .toolbar {

--- a/assets/img/lfb-logo.svg
+++ b/assets/img/lfb-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 780 240" role="img" aria-labelledby="title desc">
+  <title id="title">Logo LFB Biomanufacturing</title>
+  <desc id="desc">Trois rectangles colorés suivis du texte LFB au dessus du mot Biomanufacturing.</desc>
+  <rect x="0" y="40" width="140" height="140" fill="#4A4A4C"/>
+  <rect x="160" y="40" width="140" height="140" fill="#D2232A"/>
+  <rect x="320" y="40" width="140" height="140" fill="#7AA4BF"/>
+  <text x="490" y="140" font-family="'Arial Black', 'Montserrat', 'Helvetica Neue', Arial, sans-serif" font-size="120" font-weight="700" fill="#4A4A4C">LFB</text>
+  <text x="0" y="210" font-family="'Arial Narrow', 'Montserrat', Arial, sans-serif" font-size="40" letter-spacing="6" fill="#4A4A4C">BIOMANUFACTURING</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the header shield icon with the provided LFB Biomanufacturing branding
- add styling to position the logo in the header and improve the mobile layout
- include a reusable SVG asset for the LFB logo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cabb49d16c832eaac8ab5bc857a6ba