### PR TITLE
Add lightweight html2canvas fallback for offline capture

### DIFF
--- a/assets/libs/html2canvas.min.js
+++ b/assets/libs/html2canvas.min.js
@@ -1,0 +1,201 @@
+(function(global){
+  if (global.html2canvas) {
+    return;
+  }
+
+  function collectCSS() {
+    let cssText = "";
+    const styleSheets = Array.from(document.styleSheets || []);
+    styleSheets.forEach((sheet) => {
+      let rules;
+      try {
+        rules = sheet.cssRules;
+      } catch (err) {
+        rules = null;
+      }
+      if (!rules) {
+        return;
+      }
+      cssText += Array.from(rules).map((rule) => rule.cssText).join("\n") + "\n";
+    });
+    return cssText;
+  }
+
+  function cloneNodeInline(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return document.createTextNode(node.textContent || "");
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return node.cloneNode(false);
+    }
+
+    let clone;
+    if (node.tagName === "CANVAS") {
+      clone = document.createElement("canvas");
+      clone.width = node.width;
+      clone.height = node.height;
+      Array.from(node.attributes).forEach((attr) => {
+        clone.setAttribute(attr.name, attr.value);
+      });
+      const ctx = clone.getContext("2d");
+      if (ctx) {
+        try {
+          ctx.drawImage(node, 0, 0);
+        } catch (err) {
+          // ignore drawing errors
+        }
+      }
+    } else {
+      clone = node.cloneNode(false);
+    }
+
+    const computed = window.getComputedStyle(node);
+    let cssText = "";
+    for (let i = 0; i < computed.length; i++) {
+      const prop = computed[i];
+      const value = computed.getPropertyValue(prop);
+      if (value) {
+        cssText += `${prop}:${value};`;
+      }
+    }
+    if (cssText) {
+      clone.setAttribute("style", cssText);
+    }
+
+    if (node instanceof HTMLInputElement) {
+      clone.setAttribute("value", node.value);
+      if (node.type === "checkbox" || node.type === "radio") {
+        if (node.checked) {
+          clone.setAttribute("checked", "");
+        } else {
+          clone.removeAttribute("checked");
+        }
+      }
+    } else if (node instanceof HTMLTextAreaElement) {
+      clone.textContent = node.value;
+    } else if (node instanceof HTMLSelectElement) {
+      clone.setAttribute("value", node.value);
+    } else if (node instanceof HTMLImageElement) {
+      if (node.src) {
+        clone.setAttribute("src", node.src);
+      }
+      if (node.crossOrigin) {
+        clone.setAttribute("crossorigin", node.crossOrigin);
+      }
+    }
+
+    Array.from(node.childNodes).forEach((child) => {
+      clone.appendChild(cloneNodeInline(child));
+    });
+
+    if (node instanceof HTMLSelectElement) {
+      const originalOptions = Array.from(node.options || []);
+      const cloneOptions = Array.from(clone.options || []);
+      cloneOptions.forEach((option, index) => {
+        if (originalOptions[index] && originalOptions[index].selected) {
+          option.setAttribute("selected", "");
+        } else {
+          option.removeAttribute("selected");
+        }
+      });
+    }
+
+    return clone;
+  }
+
+  function html2canvas(element, options = {}) {
+    return new Promise((resolve, reject) => {
+      if (!(element instanceof Element)) {
+        reject(new Error("html2canvas: l'élément fourni n'est pas valide."));
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      const width = Math.max(Math.ceil(rect.width), 1);
+      const height = Math.max(Math.ceil(rect.height), 1);
+      const scale = options.scale || window.devicePixelRatio || 1;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width * scale;
+      canvas.height = height * scale;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("html2canvas: impossible de créer un contexte 2D."));
+        return;
+      }
+
+      const backgroundColor = options.backgroundColor || window.getComputedStyle(element).backgroundColor;
+      if (backgroundColor && backgroundColor !== "transparent" && backgroundColor !== "rgba(0, 0, 0, 0)") {
+        ctx.fillStyle = backgroundColor;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+      }
+
+      ctx.scale(scale, scale);
+
+      const clone = cloneNodeInline(element);
+      const wrapper = document.createElement("div");
+      wrapper.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+      wrapper.style.width = `${width}px`;
+      wrapper.style.height = `${height}px`;
+
+      const styleElement = document.createElement("style");
+      styleElement.textContent = collectCSS();
+      wrapper.appendChild(styleElement);
+      wrapper.appendChild(clone);
+
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+      svg.setAttribute("width", width);
+      svg.setAttribute("height", height);
+      svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+      const foreignObject = document.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+      foreignObject.setAttribute("width", "100%");
+      foreignObject.setAttribute("height", "100%");
+      foreignObject.appendChild(wrapper);
+      svg.appendChild(foreignObject);
+
+      const serializer = new XMLSerializer();
+      const svgString = serializer.serializeToString(svg);
+      const blob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
+      const url = URL.createObjectURL(blob);
+
+      const image = new Image();
+      let timeoutId = null;
+      if (typeof options.imageTimeout === "number" && options.imageTimeout > 0) {
+        timeoutId = setTimeout(() => {
+          image.onload = null;
+          image.onerror = null;
+          URL.revokeObjectURL(url);
+          reject(new Error("html2canvas: délai de rendu dépassé."));
+        }, options.imageTimeout);
+      }
+
+      image.onload = function () {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        try {
+          ctx.drawImage(image, 0, 0, width, height);
+          resolve(canvas);
+        } catch (err) {
+          reject(err);
+        } finally {
+          URL.revokeObjectURL(url);
+        }
+      };
+
+      image.onerror = function () {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        URL.revokeObjectURL(url);
+        reject(new Error("html2canvas: échec du rendu de la capture."));
+      };
+
+      image.src = url;
+    });
+  }
+
+  global.html2canvas = html2canvas;
+})(window);


### PR DESCRIPTION
## Summary
- add a local html2canvas implementation to restore offline matrix capture support
- ensure cloning preserves inline styles and assets for export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cabbdbe0b4832eab7fd9fcda1f15cc