### PR TITLE
Align axis labels with matrix edges

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -569,12 +569,10 @@ body {
 }
 
 .matrix.edit-matrix .axis-label.x-axis {
-    bottom: -30px;
     font-size: 0.9em;
 }
 
 .matrix.edit-matrix .axis-label.y-axis {
-    left: -55px;
     font-size: 0.9em;
 }
 
@@ -686,9 +684,6 @@ body {
         width: 100%;
     }
 
-    .matrix.edit-matrix .axis-label.y-axis {
-        left: -45px;
-    }
 }
 
 @media (max-width: 600px) {
@@ -705,9 +700,6 @@ body {
         flex: 1 1 100px;
     }
 
-    .matrix.edit-matrix .axis-label.y-axis {
-        left: -40px;
-    }
 }
 
 .axis-label {
@@ -720,16 +712,16 @@ body {
 }
 
 .axis-label.x-axis {
-    bottom: -45px;
+    bottom: 0;
     left: 50%;
-    transform: translateX(-50%);
+    transform: translate(-50%, 100%);
 }
 
 .axis-label.y-axis {
-    left: -80px;
+    left: 0;
     top: 50%;
-    transform: rotate(-90deg) translateX(50%);
-    transform-origin: center;
+    transform: translate(-100%, -50%) rotate(-90deg);
+    transform-origin: left center;
 }
 
 /* Risk Details Panel */


### PR DESCRIPTION
## Summary
- update global axis label positioning to use border-relative transforms and avoid negative offsets
- simplify edit matrix overrides so modal matrix inherits the new positioning
- remove mobile overrides that shifted the y-axis label off-screen

## Testing
- Manual Playwright check of matrix tab and risk modal at desktop and 600px widths

------
https://chatgpt.com/codex/tasks/task_e_68cad22bbfa0832ea84255643dc9387b