### PR TITLE
Replace risk evolution chart with top net risks list

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -125,9 +125,21 @@
 
                     <!-- Charts -->
                     <div class="charts-row">
-                        <div class="chart-container">
-                            <div class="chart-title">Évolution des Risques (6 derniers mois)</div>
-                            <canvas id="evolutionChart" height="200"></canvas>
+                        <div class="chart-container top-risks-container">
+                            <div class="chart-title">Top 10 des risques nets</div>
+                            <div class="top-risks-table-wrapper">
+                                <table class="top-risks-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Titre</th>
+                                            <th>Processus</th>
+                                            <th>Sous-processus</th>
+                                            <th class="score-column">Score net</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="topNetRisksBody"></tbody>
+                                </table>
+                            </div>
                         </div>
                         <div class="chart-container">
                             <div class="chart-title">Répartition par Processus</div>
@@ -143,18 +155,37 @@
                                 <button class="btn btn-secondary">Voir tout</button>
                             </div>
                         </div>
-                        <table>
-                            <thead>
-                                <tr>
-                                    <th>Date</th>
-                                    <th>Risque</th>
-                                    <th>Processus</th>
-                                    <th>Niveau</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody id="recentAlertsBody"></tbody>
-                        </table>
+                        <div class="alerts-sections">
+                            <section class="alerts-section">
+                                <div class="alerts-section-title">Risques sévères ou critiques sans plan d'actions</div>
+                                <table class="alerts-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Date</th>
+                                            <th>Risque</th>
+                                            <th>Processus</th>
+                                            <th>Niveau</th>
+                                            <th>Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="recentAlertsRisksBody"></tbody>
+                                </table>
+                            </section>
+                            <section class="alerts-section">
+                                <div class="alerts-section-title">Plan d'actions en retard</div>
+                                <table class="alerts-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Plan d'action</th>
+                                            <th>Propriétaire</th>
+                                            <th>Échéance</th>
+                                            <th>Statut</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="recentAlertsPlansBody"></tbody>
+                                </table>
+                            </section>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -911,6 +911,47 @@ body {
     margin-bottom: 15px;
 }
 
+.top-risks-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.top-risks-table-wrapper {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.top-risks-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.top-risks-table .score-column,
+.top-risks-table .top-risk-score {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.top-risks-table .top-risk-title {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.top-risks-table .top-risk-score {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.top-risks-table-wrapper::-webkit-scrollbar {
+    width: 6px;
+}
+
+.top-risks-table-wrapper::-webkit-scrollbar-thumb {
+    background: rgba(149, 165, 166, 0.4);
+    border-radius: 3px;
+}
+
 /* Table améliorée */
 .table-container {
     background: white;
@@ -936,6 +977,32 @@ body {
 .table-actions {
     display: flex;
     gap: 10px;
+}
+
+.alerts-sections {
+    display: flex;
+    flex-direction: column;
+}
+
+.alerts-section {
+    padding: 20px;
+}
+
+.alerts-section + .alerts-section {
+    border-top: 1px solid #ecf0f1;
+}
+
+.alerts-section-title {
+    font-size: 1em;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 12px;
+}
+
+.alerts-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 5px;
 }
 
 table {
@@ -970,6 +1037,13 @@ tbody tr {
 
 tbody tr:hover {
     background: var(--light-bg);
+}
+
+.table-empty {
+    text-align: center;
+    padding: 24px;
+    color: #95a5a6;
+    font-style: italic;
 }
 
 .table-badge {


### PR DESCRIPTION
## Summary
- replace the evolution chart with a Top 10 des risques nets table showing title, process, sub-process and net score
- style the new list container and empty state messaging to match dashboard visuals
- compute the validated net risk ranking in the dashboard update while keeping the process chart intact

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cadf792fac832eba5fbe1ca8bacfef