### PR TITLE
Limit risk capture list to top 10 entries

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -260,7 +260,7 @@
                             </div>
                             
                             <div class="risk-details-panel">
-                                <div class="risk-details-title">Risques dans cette vue</div>
+                                <div class="risk-details-title" id="riskDetailsTitle">Top 10 des risques - Vue Brut</div>
                                 <div id="riskDetailsList"></div>
                             </div>
                         </div>

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -1672,6 +1672,13 @@ class RiskManagementSystem {
         };
         const { prob: probKey, impact: impactKey } = viewConfig[this.currentView] || viewConfig['brut'];
 
+        const viewLabels = {
+            'brut': 'Vue Brut',
+            'net': 'Vue Net',
+            'post': 'Vue Post-Mitigation',
+            'post-mitigation': 'Vue Post-Mitigation'
+        };
+
         const scoredRisks = filteredRisks.map(risk => {
             const prob = Number(risk[probKey]) || 0;
             const impact = Number(risk[impactKey]) || 0;
@@ -1692,7 +1699,15 @@ class RiskManagementSystem {
             return String(a.risk.id).localeCompare(String(b.risk.id), undefined, { numeric: true, sensitivity: 'base' });
         });
 
-        container.innerHTML = scoredRisks.map(({ risk, score }) => {
+        const topRisks = scoredRisks.slice(0, 10);
+
+        const titleElement = document.getElementById('riskDetailsTitle');
+        if (titleElement) {
+            const viewLabel = viewLabels[this.currentView] || viewLabels['brut'];
+            titleElement.textContent = `Top 10 des risques - ${viewLabel}`;
+        }
+
+        container.innerHTML = topRisks.map(({ risk, score }) => {
             let scoreClass = 'low';
             if (score > 12) scoreClass = 'critical';
             else if (score > 8) scoreClass = 'high';


### PR DESCRIPTION
## Summary
- limit the risk details list used by the capture to the top 10 items of the current view
- update the risk details panel title to highlight the top 10 context per view

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68cb07879228832ea34c078a9728bfea