### PR TITLE
Remplace le graphique d’évolution par le top 10 des risques nets

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -125,9 +125,23 @@
 
                     <!-- Charts -->
                     <div class="charts-row">
-                        <div class="chart-container">
-                            <div class="chart-title">Évolution des Risques (6 derniers mois)</div>
-                            <canvas id="evolutionChart" height="200"></canvas>
+                        <div class="chart-container top-risks-container">
+                            <div class="chart-title">Top 10 des risques nets</div>
+                            <div class="top-risks-content" id="topRisksContent">
+                                <table class="top-risks-table">
+                                    <thead>
+                                        <tr>
+                                            <th>#</th>
+                                            <th>Titre</th>
+                                            <th>Processus</th>
+                                            <th>Sous-processus</th>
+                                            <th>Score net</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="topRisksTableBody"></tbody>
+                                </table>
+                                <div class="top-risks-empty">Aucun risque à afficher</div>
+                            </div>
                         </div>
                         <div class="chart-container process-charts">
                             <div class="chart-title">Répartition par Processus</div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -948,6 +948,79 @@ body {
     }
 }
 
+.top-risks-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.top-risks-content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.top-risks-content.is-empty .top-risks-table {
+    display: none;
+}
+
+.top-risks-content .top-risks-empty {
+    display: none;
+    padding: 18px 12px;
+    text-align: center;
+    border: 1px dashed #d6e2eb;
+    border-radius: 12px;
+    color: #7f8c8d;
+    background: #f9fbfd;
+    font-size: 0.95em;
+}
+
+.top-risks-content.is-empty .top-risks-empty {
+    display: block;
+}
+
+.top-risks-table th:first-child,
+.top-risks-table td:first-child {
+    width: 56px;
+    text-align: center;
+    font-weight: 600;
+    color: #95a5a6;
+}
+
+.top-risks-table th:last-child {
+    text-align: right;
+}
+
+.top-risks-table td {
+    vertical-align: middle;
+}
+
+.top-risk-title {
+    font-weight: 600;
+    color: #2c3e50;
+    display: block;
+}
+
+.top-risk-meta {
+    font-size: 0.85em;
+    color: #7f8c8d;
+}
+
+.top-risk-process {
+    font-weight: 500;
+    color: #34495e;
+}
+
+.top-risk-subprocess {
+    color: #7f8c8d;
+}
+
+.top-risk-score {
+    font-weight: 700;
+    text-align: right;
+    color: var(--primary-color);
+    font-variant-numeric: tabular-nums;
+}
+
 /* Table améliorée */
 .table-container {
     background: white;


### PR DESCRIPTION
## Résumé
- remplace le graphique "Évolution des risques" du tableau de bord par une nouvelle section dédiée au top 10 des risques nets
- ajoute les styles nécessaires pour la table de synthèse et son état vide
- calcule et affiche dynamiquement le classement des risques nets à partir des données filtrées

## Tests
- non applicable


------
https://chatgpt.com/codex/tasks/task_e_68cb0d5a4160832eb7ae37710f0a1a50