### PR TITLE
Replace global score card with action plan status chart

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -113,13 +113,18 @@
                             <div class="stat-change positive">↑ +3 nouveaux</div>
                         </div>
                         
-                        <div class="stat-card primary">
+                        <div class="stat-card plan-status-card">
                             <div class="stat-header">
-                                <span class="stat-title">Score Global</span>
-                                <span class="stat-icon">📊</span>
+                                <span class="stat-title">Plans d'actions par statut</span>
+                                <span class="stat-icon">🗂️</span>
                             </div>
-                            <div class="stat-value primary">72%</div>
-                            <div class="stat-change positive">↑ +5% d'amélioration</div>
+                            <div class="plan-status-total" id="actionPlanStatusTotal">Aucun plan d'action</div>
+                            <div class="plan-status-chart">
+                                <canvas id="actionPlanStatusChart" height="160"></canvas>
+                            </div>
+                            <div class="plan-status-summary" id="actionPlanStatusSummary">
+                                <div class="plan-status-empty">Aucun plan d'action enregistré</div>
+                            </div>
                         </div>
                     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -843,6 +843,7 @@ body {
 .stat-card.success { border-left-color: var(--success-color); }
 .stat-card.warning { border-left-color: var(--warning-color); }
 .stat-card.danger { border-left-color: var(--danger-color); }
+.stat-card.plan-status-card { border-left-color: var(--primary-color); }
 
 .stat-header {
     display: flex;
@@ -879,6 +880,61 @@ body {
 .stat-change {
     font-size: 0.85em;
     color: #7f8c8d;
+}
+
+.plan-status-total {
+    font-size: 1.2em;
+    font-weight: 600;
+    color: #2c3e50;
+    margin-bottom: 12px;
+}
+
+.plan-status-chart {
+    position: relative;
+    height: 180px;
+    margin-bottom: 15px;
+}
+
+.plan-status-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.plan-status-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95em;
+    color: #34495e;
+}
+
+.plan-status-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.plan-status-label {
+    font-weight: 500;
+    color: #2c3e50;
+}
+
+.plan-status-color {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.plan-status-count {
+    font-weight: 600;
+    color: #2c3e50;
+}
+
+.plan-status-empty {
+    color: #7f8c8d;
+    font-style: italic;
 }
 
 .stat-change.positive { color: var(--success-color); }


### PR DESCRIPTION
## Summary
- replace the maturity score KPI card with a new action plan status card on the dashboard
- style the new card with dedicated layout and legend formatting for counts per status
- compute action plan status metrics and render a doughnut chart with counts and legend details

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb155c5890832eb139ebe1e848e155