### PR TITLE
Update dashboard badge to show alert count

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -42,7 +42,7 @@
             <div class="tabs-container">
                 <button class="tab active" onclick="switchTab('dashboard')">
                     📊 Tableau de Bord
-                    <span class="tab-badge">3</span>
+                    <span class="tab-badge">0</span>
                 </button>
                 <button class="tab" onclick="switchTab('matrix')">
                     📈 Matrice des Risques

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -2477,11 +2477,13 @@ class RiskManagementSystem {
         const risksBody = document.getElementById('recentAlertsRisksBody');
         const plansBody = document.getElementById('recentAlertsPlansBody');
 
+        const { severeRisks, overdueActionPlans } = this.getRecentAlertsData(risks);
+
+        this.updateDashboardBadge(severeRisks.length + overdueActionPlans.length);
+
         if (!risksBody && !plansBody) {
             return;
         }
-
-        const { severeRisks, overdueActionPlans } = this.getRecentAlertsData(risks);
 
         if (risksBody) {
             if (severeRisks.length === 0) {
@@ -2528,6 +2530,17 @@ class RiskManagementSystem {
                     `).join('');
             }
         }
+    }
+
+    updateDashboardBadge(count = 0) {
+        const dashboardBadge = document.querySelector('.tabs-container .tab .tab-badge');
+        if (!dashboardBadge) {
+            return;
+        }
+
+        const numericCount = Number(count);
+        const safeCount = Number.isFinite(numericCount) ? Math.max(0, Math.trunc(numericCount)) : 0;
+        dashboardBadge.textContent = String(safeCount);
     }
 
     calculateStats(risks = this.risks) {
@@ -2847,13 +2860,6 @@ class RiskManagementSystem {
             }
         }
 
-        const badgeStats = stats || this.calculateStats(baseRisks);
-        const dashboardBadge = document.querySelector('.tabs-container .tab .tab-badge');
-        if (dashboardBadge) {
-            const criticalCount = Number(badgeStats?.critical) || 0;
-            const highCount = Number(badgeStats?.high) || 0;
-            dashboardBadge.textContent = String(criticalCount + highCount);
-        }
     }
 
     // Risk list functions


### PR DESCRIPTION
## Summary
- replace the dashboard tab badge logic so it displays the number of alert entries (severe risks and overdue plans) shown in the dashboard alerts block
- add a helper that safely updates the badge and set the static markup default to 0 so the badge starts empty

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb973ae664832ea90ee100efd385e8