### PR TITLE
Renommer les types de contrôles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1427,12 +1427,12 @@ tbody tr:hover {
     text-transform: uppercase;
 }
 
-.control-type-badge.preventif {
+.control-type-badge.a-priori {
     background: #e8f5e8;
     color: #27ae60;
 }
 
-.control-type-badge.detectif {
+.control-type-badge.a-posteriori {
     background: #fff3cd;
     color: #856404;
 }

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -273,7 +273,7 @@ class RiskManagementSystem {
                 name: "Procédure de validation des dépenses",
                 description: "Double validation pour toute dépense > 1000€",
                 effectiveness: "forte",
-                type: "preventif",
+                type: "a-priori",
                 owner: "Directeur Financier",
                 frequency: "quotidienne",
                 mode: "manuel",
@@ -286,7 +286,7 @@ class RiskManagementSystem {
                 name: "Due diligence tiers",
                 description: "Vérification approfondie de tous les nouveaux partenaires",
                 effectiveness: "forte",
-                type: "preventif",
+                type: "a-priori",
                 owner: "Service Juridique",
                 frequency: "ad-hoc",
                 mode: "manuel",
@@ -299,7 +299,7 @@ class RiskManagementSystem {
                 name: "Audit interne trimestriel",
                 description: "Revue complète des processus à risque",
                 effectiveness: "moyenne",
-                type: "detectif",
+                type: "a-posteriori",
                 owner: "Audit Interne",
                 frequency: "mensuelle",
                 mode: "manuel",
@@ -312,7 +312,7 @@ class RiskManagementSystem {
                 name: "Formation anti-corruption",
                 description: "Formation obligatoire annuelle pour tous les employés",
                 effectiveness: "moyenne",
-                type: "preventif",
+                type: "a-priori",
                 owner: "Ressources Humaines",
                 frequency: "annuelle",
                 mode: "manuel",
@@ -422,8 +422,8 @@ class RiskManagementSystem {
                 { value: 'termine', label: 'Terminé' }
             ],
             controlTypes: [
-                { value: 'preventif', label: 'Préventif' },
-                { value: 'detectif', label: 'Détectif' }
+                { value: 'a-priori', label: 'A priori' },
+                { value: 'a-posteriori', label: 'A posteriori' }
             ],
             controlFrequencies: [
                 { value: 'quotidienne', label: 'Quotidienne' },


### PR DESCRIPTION
## Summary
- remplacer les types de contrôle `Préventif` et `Détectif` par `A priori` et `A posteriori` dans les données par défaut
- ajuster la configuration des types de contrôles pour refléter les nouvelles valeurs
- mettre à jour les styles associés aux badges de type de contrôle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba31049d8832eb7b38cde952a0adb