### PR TITLE
Add offline Chart.js replacement

### DIFF
--- a/assets/libs/chart.umd.min.js
+++ b/assets/libs/chart.umd.min.js
@@ -1,0 +1,255 @@
+(function(g,f){
+  if(typeof module==='object'&&module.exports){
+    module.exports=f();
+  }else if(typeof define==='function'&&define.amd){
+    define([],f);
+  }else{
+    g.Chart=f();
+  }
+})(typeof window!=='undefined'?window:this,function(){
+  function Chart(el,cfg){
+    if(!(this instanceof Chart)) return new Chart(el,cfg);
+    this.canvas=typeof el==='string'?document.getElementById(el):el;
+    if(!(this.canvas&&this.canvas.getContext)) throw new Error('Canvas required');
+    this.ctx=this.canvas.getContext('2d');
+    cfg=cfg||{};
+    this.type=cfg.type||'doughnut';
+    this.data=cfg.data||{labels:[],datasets:[]};
+    this.options=cfg.options||{};
+    this.chartArea={left:0,top:0,right:0,bottom:0,width:0,height:0};
+    Chart._instances.set(this.canvas,this);
+    this.update();
+  }
+  Chart.version='4.4.4-lite';
+  Chart._instances=new Map();
+  Chart._plugins=[];
+  Chart.register=function(plugin){
+    if(plugin&&Chart._plugins.indexOf(plugin)<0) Chart._plugins.push(plugin);
+  };
+  Chart.plugins={ register: Chart.register };
+  Chart.getChart=function(el){
+    var node=typeof el==='string'?document.getElementById(el):el;
+    return node?Chart._instances.get(node)||null:null;
+  };
+  Chart.prototype.destroy=function(){
+    Chart._instances.delete(this.canvas);
+    if(this.ctx){
+      this.ctx.setTransform(1,0,0,1,0,0);
+      this.ctx.clearRect(0,0,this.canvas.width,this.canvas.height);
+    }
+  };
+  Chart.prototype.update=function(){
+    if(!this.ctx) return;
+    var rect=this.canvas.getBoundingClientRect();
+    var w=rect.width||this.canvas.width||300;
+    var h=rect.height||this.canvas.height||150;
+    if(w<10) w=10;
+    if(h<10) h=10;
+    if(this.canvas.width!==w) this.canvas.width=w;
+    if(this.canvas.height!==h) this.canvas.height=h;
+    this.chartArea={left:0,top:0,right:w,bottom:h,width:w,height:h};
+    this.ctx.setTransform(1,0,0,1,0,0);
+    this.ctx.clearRect(0,0,w,h);
+    this._runPlugins('beforeDraw');
+    (this.type==='bar'?this._drawBar:this._drawDoughnut).call(this);
+    this._runPlugins('afterDraw');
+  };
+  Chart.prototype._runPlugins=function(hook){
+    for(var i=0;i<Chart._plugins.length;i++){
+      var plugin=Chart._plugins[i];
+      if(!plugin) continue;
+      var fn=plugin[hook];
+      if(typeof fn!=='function') continue;
+      var opts=this._pluginOptions(plugin);
+      if(opts===false) continue;
+      try{
+        fn(this,{},opts);
+      }catch(err){
+        console.warn('Chart plugin error',err);
+      }
+    }
+  };
+  Chart.prototype._pluginOptions=function(plugin){
+    var defaults=plugin.defaults||{};
+    var id=plugin.id;
+    if(!id) return defaults;
+    var local=this.options&&this.options.plugins?this.options.plugins[id]:undefined;
+    if(local===false) return false;
+    var out={};
+    for(var key in defaults){ out[key]=defaults[key]; }
+    if(local&&typeof local==='object'){
+      for(var k in local){ out[k]=local[k]; }
+    }
+    return out;
+  };
+  Chart.prototype._dataset=function(){
+    var sets=this.data&&this.data.datasets;
+    return Array.isArray(sets)&&sets.length?sets[0]:{data:[]};
+  };
+  Chart.prototype._numbers=function(list){
+    var out=[];
+    if(!Array.isArray(list)) return out;
+    for(var i=0;i<list.length;i++){
+      var num=Number(list[i]);
+      out.push(Number.isFinite(num)?num:0);
+    }
+    return out;
+  };
+  Chart.prototype._colors=function(src,len,fallback){
+    var out=[];
+    if(Array.isArray(src)&&src.length){
+      for(var i=0;i<len;i++) out.push(src[i%src.length]||fallback);
+      return out;
+    }
+    if(typeof src==='string'){
+      for(var j=0;j<len;j++) out.push(src);
+      return out;
+    }
+    for(var k=0;k<len;k++) out.push(fallback);
+    return out;
+  };
+  Chart.prototype._drawDoughnut=function(){
+    var ctx=this.ctx;
+    var area=this.chartArea;
+    var dataset=this._dataset();
+    var data=this._numbers(dataset.data);
+    var total=0;
+    for(var i=0;i<data.length;i++){
+      if(data[i]>0) total+=data[i];
+    }
+    var colors=this._colors(dataset.backgroundColor,data.length,'rgba(52,152,219,0.85)');
+    var borders=this._colors(dataset.borderColor,data.length,'rgba(41,128,185,1)');
+    var borderWidth=Math.max(0,Number(dataset.borderWidth)||0);
+    var cx=area.width/2;
+    var cy=area.height/2;
+    var radius=Math.max(Math.min(area.width,area.height)/2-8,8);
+    var cut=0;
+    var optCut=this.options&&this.options.cutout;
+    if(typeof optCut==='string'&&optCut.indexOf('%')>-1){
+      cut=parseFloat(optCut)/100;
+    }else if(typeof optCut==='number'){
+      cut=optCut;
+    }
+    if(!Number.isFinite(cut)||cut<0) cut=0;
+    if(cut>0.95) cut=0.95;
+    var start=-Math.PI/2;
+    ctx.save();
+    ctx.translate(0.5,0.5);
+    if(total>0){
+      for(var j=0;j<data.length;j++){
+        var value=data[j];
+        if(value<=0) continue;
+        var angle=value/total*Math.PI*2;
+        var end=start+angle;
+        ctx.beginPath();
+        ctx.moveTo(cx,cy);
+        ctx.fillStyle=colors[j];
+        ctx.arc(cx,cy,radius,start,end);
+        ctx.closePath();
+        ctx.fill();
+        if(borderWidth>0){
+          ctx.lineWidth=borderWidth;
+          ctx.strokeStyle=borders[j];
+          ctx.stroke();
+        }
+        start=end;
+      }
+      if(cut>0){
+        ctx.save();
+        ctx.globalCompositeOperation='destination-out';
+        ctx.beginPath();
+        ctx.arc(cx,cy,radius*cut,0,Math.PI*2);
+        ctx.fill();
+        ctx.restore();
+      }
+    }
+    ctx.restore();
+  };
+  Chart.prototype._max=function(values){
+    var max=0;
+    for(var i=0;i<values.length;i++){
+      if(values[i]>max) max=values[i];
+    }
+    var axis=this.options&&this.options.scales;
+    var key=this.options&&this.options.indexAxis==='y'?'x':'y';
+    if(axis&&axis[key]){
+      if(typeof axis[key].max==='number'&&axis[key].max>0) max=axis[key].max;
+      else if(typeof axis[key].suggestedMax==='number'&&axis[key].suggestedMax>max) max=axis[key].suggestedMax;
+    }
+    if(max<=0) max=1;
+    return max;
+  };
+  Chart.prototype._drawBar=function(){
+    var ctx=this.ctx;
+    var area=this.chartArea;
+    var dataset=this._dataset();
+    var data=this._numbers(dataset.data);
+    var labels=Array.isArray(this.data&&this.data.labels)?this.data.labels:[];
+    var colors=this._colors(dataset.backgroundColor,data.length,'rgba(52,152,219,0.85)');
+    var borders=this._colors(dataset.borderColor,data.length,'rgba(41,128,185,1)');
+    var borderWidth=Math.max(0,Number(dataset.borderWidth)||0);
+    var horizontal=this.options&&this.options.indexAxis==='y';
+    var pad={top:20,right:32,bottom:36,left:horizontal?Math.min(200,Math.max(110,area.width*0.3)):48};
+    var width=Math.max(area.width-pad.left-pad.right,10);
+    var height=Math.max(area.height-pad.top-pad.bottom,10);
+    ctx.save();
+    ctx.translate(0.5,0.5);
+    ctx.font="14px 'Inter','Arial',sans-serif";
+    ctx.textBaseline='middle';
+    if(horizontal){
+      var step=height/(data.length||1);
+      var barHeight=Math.max(Math.min(step*0.6,48),6);
+      var max=this._max(data);
+      for(var i=0;i<data.length;i++){
+        var value=data[i];
+        var len=max?value/max*width:0;
+        var y=pad.top+i*step+(step-barHeight)/2;
+        ctx.fillStyle=colors[i];
+        ctx.fillRect(pad.left,y,len,barHeight);
+        if(borderWidth){
+          ctx.lineWidth=borderWidth;
+          ctx.strokeStyle=borders[i];
+          ctx.strokeRect(pad.left,y,len,barHeight);
+        }
+        ctx.fillStyle='#2c3e50';
+        ctx.textAlign='right';
+        ctx.fillText(labels[i]||'',pad.left-8,y+barHeight/2);
+        ctx.textAlign='left';
+        ctx.fillText(value.toLocaleString('fr-FR'),pad.left+len+6,y+barHeight/2);
+      }
+      ctx.strokeStyle='rgba(127,140,141,0.8)';
+      ctx.beginPath();
+      ctx.moveTo(pad.left,pad.top+height);
+      ctx.lineTo(pad.left+width,pad.top+height);
+      ctx.stroke();
+    }else{
+      var stepX=width/(data.length||1);
+      var barWidth=Math.max(Math.min(stepX*0.6,80),6);
+      var maxY=this._max(data);
+      ctx.textAlign='center';
+      for(var j=0;j<data.length;j++){
+        var val=data[j];
+        var h=maxY?val/maxY*height:0;
+        var x=pad.left+j*stepX+(stepX-barWidth)/2;
+        var y=pad.top+height-h;
+        ctx.fillStyle=colors[j];
+        ctx.fillRect(x,y,barWidth,h);
+        if(borderWidth){
+          ctx.lineWidth=borderWidth;
+          ctx.strokeStyle=borders[j];
+          ctx.strokeRect(x,y,barWidth,h);
+        }
+        ctx.fillStyle='#2c3e50';
+        ctx.fillText(labels[j]||'',x+barWidth/2,pad.top+height+14);
+        ctx.fillText(val.toLocaleString('fr-FR'),x+barWidth/2,y-10);
+      }
+      ctx.strokeStyle='rgba(127,140,141,0.8)';
+      ctx.beginPath();
+      ctx.moveTo(pad.left,pad.top+height);
+      ctx.lineTo(pad.left+width,pad.top+height);
+      ctx.stroke();
+    }
+    ctx.restore();
+  };
+  return Chart;
+});


### PR DESCRIPTION
## Summary
- add a self-contained Chart-compatible UMD bundle under `assets/libs` so the dashboard works offline

## Testing
- `python -m http.server 8000` (manually opened `http://localhost:8000/CartoModel.html` to verify the charts render)


------
https://chatgpt.com/codex/tasks/task_e_68cba407bd24832e9161ee25bce2c1b3