### PR TITLE
Remove top 10 limit from risk list

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -131,7 +131,7 @@
                     <!-- Charts -->
                     <div class="charts-row">
                         <div class="chart-container top-risks-container">
-                            <div class="chart-title">Top 10 des risques nets</div>
+                            <div class="chart-title">Risques nets triés par score</div>
                             <div class="top-risks-content" id="topRisksContent">
                                 <table class="top-risks-table">
                                     <thead>
@@ -279,7 +279,7 @@
                             </div>
                             
                             <div class="risk-details-panel">
-                                <div class="risk-details-title" id="riskDetailsTitle">Top 10 des risques - Vue Brut</div>
+                                <div class="risk-details-title" id="riskDetailsTitle">Risques triés par score - Vue Brut</div>
                                 <div id="riskDetailsList"></div>
                             </div>
                         </div>

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -1735,15 +1735,13 @@ class RiskManagementSystem {
             return String(a.risk.id).localeCompare(String(b.risk.id), undefined, { numeric: true, sensitivity: 'base' });
         });
 
-        const topRisks = scoredRisks.slice(0, 10);
-
         const titleElement = document.getElementById('riskDetailsTitle');
         if (titleElement) {
             const viewLabel = viewLabels[this.currentView] || viewLabels['brut'];
-            titleElement.textContent = `Top 10 des risques - ${viewLabel}`;
+            titleElement.textContent = `Risques triés par score - ${viewLabel}`;
         }
 
-        container.innerHTML = topRisks.map(({ risk, score }) => {
+        container.innerHTML = scoredRisks.map(({ risk, score }) => {
             let scoreClass = 'low';
             if (score > 12) scoreClass = 'critical';
             else if (score > 8) scoreClass = 'high';


### PR DESCRIPTION
## Summary
- show the entire filtered risk list in the matrix side panel instead of slicing to the top 10
- update titles to reflect that the list is now ordered by score without a top 10 limit

## Testing
- not run (frontend change)


------
https://chatgpt.com/codex/tasks/task_e_68cba41c2584832e92468c8bf7b6d0a9