### PR TITLE
Adjust vertical axis label positioning

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -713,10 +713,10 @@ body {
 }
 
 .axis-label.y-axis {
-    left: 0;
     top: 50%;
-    transform: translate(-50%, 50%) rotate(-90deg);
-    transform-origin: left center;
+    left: -3rem;
+    transform: translateY(-50%) rotate(-90deg);
+    transform-origin: center;
 }
 
 /* Risk Details Panel */


### PR DESCRIPTION
## Summary
- center the vertical axis label before rotating so the probability text displays correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbd7354be8832eb32f1620cc0fa984