### PR TITLE
Show mention contexts in mentions modal, rename mindmap templates, bump version to 2.14.17

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -747,7 +747,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.16</span>
+            <span class="app-version">Version 2.14.17</span>
         </footer>
     </div>
 

--- a/mindmap/script.js
+++ b/mindmap/script.js
@@ -129,7 +129,7 @@ const translations = {
     },
     mapTemplates: {
       'lfb-fournisseur': {
-        name: 'LFB Fournisseur',
+        name: 'LFB acteur',
         columns: {
           objective: { label: 'Objectif', placeholder: 'Nouvel objectif' },
           tier: { label: 'Tiers', placeholder: 'Nouveau tiers' },
@@ -142,7 +142,7 @@ const translations = {
         synthese: { tierConnector: 'de' },
       },
       'lfb-client': {
-        name: 'LFB Client',
+        name: 'LFB victime',
         columns: {
           tier: { label: 'Tiers', placeholder: 'Nouveau tiers' },
           objective: { label: 'Objectif', placeholder: 'Nouvel objectif' },
@@ -155,7 +155,7 @@ const translations = {
         synthese: { tierConnector: 'par' },
       },
       'lfb-controleur': {
-        name: 'LFB contrôleur',
+        name: 'Contrôles',
         columns: {
           controle: { label: 'Contrôle', placeholder: 'Nouveau contrôle' },
           description: { label: 'Description', placeholder: 'Nouvelle description' },


### PR DESCRIPTION
### Motivation
- Surface the text following `@` mentions so the "A éclaircir" mentions modal provides context for each mention.  
- Ensure mindmap templates reflect updated LFB terminology.  
- Keep the app footer version in sync per-task by bumping to `Version 2.14.17`.  

### Description
- Added `extractMentionsWithContext` and `extractMentionContextsFromNotes` to collect `@` mentions plus the text that follows them and used those in the mentions collection flow in `assets/js/rms.core.js`.  
- Updated mentions collection from mindmap nodes to include per-mention `context` and deduplicate by mention key.  
- Propagated mention contexts into the modal entries so interview notes and mindmap nodes show the following text as `context`.  
- Renamed mindmap template labels in `mindmap/script.js` to `LFB acteur`, `LFB victime`, and `Contrôles`, and bumped the footer in `CartoModel.html` to `Version 2.14.17`.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` to serve `CartoModel.html` (succeeded).  
- Attempted Playwright end-to-end script to open the mentions modal and capture a screenshot, but the runs failed due to timeouts and a missing `rms` reference in the page (failed).  
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d0fb38b8832eb5dbc3d0f1cc6fe9)