### PR TITLE
Fallback to XHR for local interview JSON loading; bump footer version to 2.14.19

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -747,7 +747,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.18</span>
+            <span class="app-version">Version 2.14.19</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -6440,7 +6440,7 @@ class RiskManagementSystem {
         try {
             const response = await fetch(targetPath, { cache: 'no-store' });
             if (!response.ok) {
-                return null;
+                return this.fetchInterviewJsonViaXhr(targetPath);
             }
             const data = await response.json();
             return this.extractInterviewPayload(data);


### PR DESCRIPTION
### Motivation
- The app failed to load interview files when run locally (e.g. via `file://`) because `fetch` can return a non-OK response in that environment. 
- Provide a robust local fallback so interviews in the `interviews` folder are discoverable without relying on server behavior. 
- Keep the visible application version up-to-date in the footer as required. 

### Description
- In `assets/js/rms.core.js`, `fetchInterviewJson` now calls `fetchInterviewJsonViaXhr(targetPath)` when `fetch` returns a non-OK response, ensuring a fallback to XHR for local file loading. 
- Preserved the existing try/catch behavior so network errors also fall back to the XHR loader. 
- Updated the footer version in `CartoModel.html` from `Version 2.14.18` to `Version 2.14.19`. 
- Modified files: `assets/js/rms.core.js` and `CartoModel.html`.

### Testing
- No automated tests were executed as part of this change. 
- Changes were committed and staged in the repository (local verification of files modified). 
- Manual runtime verification was not recorded in automated test output. 
- Further automated or manual tests are recommended to validate behavior on both local (`file://`) and HTTP(S) environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696625c514b4832ea3e0b8a5ae592f33)