### PR TITLE
Add local interview folder loader (interviewX.json) and bump footer version

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -312,6 +312,9 @@
                         <button class="btn btn-primary" onclick="rms.openInterviewModal()">
                             + Nouveau compte-rendu
                         </button>
+                        <button class="btn btn-outline" type="button" onclick="rms.openInterviewFolderPicker()">
+                            📂 Charger un dossier d'interviews
+                        </button>
                         <button class="btn btn-secondary" type="button" onclick="rms.openMentionsModal()">
                             A éclaircir
                         </button>
@@ -747,7 +750,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.21</span>
+            <span class="app-version">Version 2.14.22</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3098,6 +3098,10 @@ tbody tr:hover {
     font-size: 0.95em;
 }
 
+.interview-empty .btn {
+    margin-top: 1rem;
+}
+
 .interview-card {
     background: #ffffff;
     border: 1px solid var(--border-color);


### PR DESCRIPTION
### Motivation
- Users downloading the project could not easily load the `interviews/` JSON files in the browser, so a local import flow is needed.
- Provide a way to load a whole folder of `interviewX.json` files without adding more hardcoded paths or filenames.
- Improve the empty-state to guide users to import local interviews when none are loaded. 
- Update the footer version as required to `2.14.22`.

### Description
- Add a toolbar button in the Interviews tab and an empty-state prompt to trigger a local folder picker (`CartoModel.html` and `assets/css/main.css`).
- Implement folder picker and parsing logic in `assets/js/rms.core.js` with `supportsInterviewFolderPicker`, `openInterviewFolderPicker`, `readInterviewFile`, and `handleInterviewFolderSelection` to load files matching `interview\d+\.json` and normalize them into `this.interviews`.
- Keep existing processing by reusing `extractInterviewPayload`, `normalizeInterview`, and updating `interviewFileCount`/`interviewJsonCount` followed by `updateInterviewsList` to re-render the UI.
- Bump footer version to `2.14.22`.

### Testing
- An automated Playwright attempt to load `CartoModel.html` and capture a screenshot was executed but failed due to a browser crash (SIGSEGV), so the UI test did not complete.
- No other automated tests (unit or e2e) were run in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69664abc90c0832e80dbc4a1c1e1b667)