### PR TITLE
Rattache les interviews 31–81 aux processus/sous‑processus

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -750,7 +750,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.24</span>
+            <span class="app-version">Version 2.14.25</span>
         </footer>
     </div>
 

--- a/interviews/interview31.json
+++ b/interviews/interview31.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Paiements exceptionnels"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview32.json
+++ b/interviews/interview32.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Notes de frais management"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview33.json
+++ b/interviews/interview33.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Prestataires cybersécurité"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview34.json
+++ b/interviews/interview34.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Attribution licences logicielles"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview35.json
+++ b/interviews/interview35.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Recrutement profils clés"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview36.json
+++ b/interviews/interview36.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Mobilité internationale"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview37.json
+++ b/interviews/interview37.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Qualité"
+  ],
+  "subProcesses": [
+    "Inspections GMP"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview38.json
+++ b/interviews/interview38.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Juridique & Compliance"
+  ],
+  "subProcesses": [
+    "Due diligence tiers"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview39.json
+++ b/interviews/interview39.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Market Access"
+  ],
+  "subProcesses": [
+    "Subventions associations patients"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview40.json
+++ b/interviews/interview40.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Direction industrielle"
+  ],
+  "subProcesses": [
+    "Permis environnementaux"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview41.json
+++ b/interviews/interview41.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Achats"
+  ],
+  "subProcesses": [
+    "Sourcing matières plasmatiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview42.json
+++ b/interviews/interview42.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Achats"
+  ],
+  "subProcesses": [
+    "Qualification fournisseurs critiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview43.json
+++ b/interviews/interview43.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Ventes & Accès marché"
+  ],
+  "subProcesses": [
+    "Appels d'offres hôpitaux publics"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview44.json
+++ b/interviews/interview44.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Ventes & Accès marché"
+  ],
+  "subProcesses": [
+    "Remises commerciales distributeurs"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview45.json
+++ b/interviews/interview45.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Affaires médicales"
+  ],
+  "subProcesses": [
+    "Contrats de conseil avec KOL"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview46.json
+++ b/interviews/interview46.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Affaires médicales"
+  ],
+  "subProcesses": [
+    "Hospitalité congrès scientifiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview47.json
+++ b/interviews/interview47.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "R&D Clinique"
+  ],
+  "subProcesses": [
+    "Sélection des centres investigateurs"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview48.json
+++ b/interviews/interview48.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "R&D Clinique"
+  ],
+  "subProcesses": [
+    "Gestion CRO internationales"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview49.json
+++ b/interviews/interview49.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Supply Chain"
+  ],
+  "subProcesses": [
+    "Dédouanement lots biologiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview50.json
+++ b/interviews/interview50.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Supply Chain"
+  ],
+  "subProcesses": [
+    "Transport sous chaîne du froid"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview51.json
+++ b/interviews/interview51.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Paiements exceptionnels"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview52.json
+++ b/interviews/interview52.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Notes de frais management"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview53.json
+++ b/interviews/interview53.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Prestataires cybersécurité"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview54.json
+++ b/interviews/interview54.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Attribution licences logicielles"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview55.json
+++ b/interviews/interview55.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Recrutement profils clés"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview56.json
+++ b/interviews/interview56.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Mobilité internationale"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview57.json
+++ b/interviews/interview57.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Qualité"
+  ],
+  "subProcesses": [
+    "Inspections GMP"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview58.json
+++ b/interviews/interview58.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Juridique & Compliance"
+  ],
+  "subProcesses": [
+    "Due diligence tiers"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview59.json
+++ b/interviews/interview59.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Market Access"
+  ],
+  "subProcesses": [
+    "Subventions associations patients"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview60.json
+++ b/interviews/interview60.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Direction industrielle"
+  ],
+  "subProcesses": [
+    "Permis environnementaux"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview61.json
+++ b/interviews/interview61.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Achats"
+  ],
+  "subProcesses": [
+    "Sourcing matières plasmatiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview62.json
+++ b/interviews/interview62.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Achats"
+  ],
+  "subProcesses": [
+    "Qualification fournisseurs critiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview63.json
+++ b/interviews/interview63.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Ventes & Accès marché"
+  ],
+  "subProcesses": [
+    "Appels d'offres hôpitaux publics"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview64.json
+++ b/interviews/interview64.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Ventes & Accès marché"
+  ],
+  "subProcesses": [
+    "Remises commerciales distributeurs"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview65.json
+++ b/interviews/interview65.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Affaires médicales"
+  ],
+  "subProcesses": [
+    "Contrats de conseil avec KOL"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview66.json
+++ b/interviews/interview66.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Affaires médicales"
+  ],
+  "subProcesses": [
+    "Hospitalité congrès scientifiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview67.json
+++ b/interviews/interview67.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "R&D Clinique"
+  ],
+  "subProcesses": [
+    "Sélection des centres investigateurs"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview68.json
+++ b/interviews/interview68.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "R&D Clinique"
+  ],
+  "subProcesses": [
+    "Gestion CRO internationales"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview69.json
+++ b/interviews/interview69.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Supply Chain"
+  ],
+  "subProcesses": [
+    "Dédouanement lots biologiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview70.json
+++ b/interviews/interview70.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Supply Chain"
+  ],
+  "subProcesses": [
+    "Transport sous chaîne du froid"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview71.json
+++ b/interviews/interview71.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Paiements exceptionnels"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview72.json
+++ b/interviews/interview72.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Finance"
+  ],
+  "subProcesses": [
+    "Notes de frais management"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview73.json
+++ b/interviews/interview73.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Prestataires cybersécurité"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview74.json
+++ b/interviews/interview74.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "IT & Digital"
+  ],
+  "subProcesses": [
+    "Attribution licences logicielles"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview75.json
+++ b/interviews/interview75.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Recrutement profils clés"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview76.json
+++ b/interviews/interview76.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "RH"
+  ],
+  "subProcesses": [
+    "Mobilité internationale"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview77.json
+++ b/interviews/interview77.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Qualité"
+  ],
+  "subProcesses": [
+    "Inspections GMP"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview78.json
+++ b/interviews/interview78.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Juridique & Compliance"
+  ],
+  "subProcesses": [
+    "Due diligence tiers"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview79.json
+++ b/interviews/interview79.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Market Access"
+  ],
+  "subProcesses": [
+    "Subventions associations patients"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview80.json
+++ b/interviews/interview80.json
@@ -8,9 +8,16 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "Groupe",
+    "International"
+  ],
+  "processes": [
+    "Direction industrielle"
+  ],
+  "subProcesses": [
+    "Permis environnementaux"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {

--- a/interviews/interview81.json
+++ b/interviews/interview81.json
@@ -8,9 +8,15 @@
   ],
   "date": "2026-01-09",
   "notes": "",
-  "scopes": [],
-  "processes": [],
-  "subProcesses": [],
+  "scopes": [
+    "France"
+  ],
+  "processes": [
+    "Achats"
+  ],
+  "subProcesses": [
+    "Sourcing matières plasmatiques"
+  ],
   "createdAt": "2026-01-09T16:20:44Z",
   "updatedAt": "2026-01-09T16:20:44Z",
   "mindMap": {


### PR DESCRIPTION
### Motivation
- Réparer l'index d'interviews en rattachant les comptes‑rendus non renseignés à des `processes`/`subProcesses` et `scopes` afin que les filtres et les regroupements par processus fonctionnent correctement dans l'application.
- Mettre à jour le numéro de version affiché dans le footer conformément à la consigne de versionnement dans le footer (`2.14.25`).

### Description
- Mise à jour du footer dans `CartoModel.html` pour afficher `Version 2.14.25`.
- Complétion des fichiers `interviews/interview31.json` à `interviews/interview81.json` en ajoutant des champs `scopes`, `processes` et `subProcesses` cohérents avec le jeu de données existant.
- Les valeurs ajoutées suivent la matrice de processus/sous-processus déjà utilisée pour les 30 premières interviews afin d'harmoniser le dataset.
- Modifications appliquées aux fichiers `CartoModel.html` et `interviews/interview31.json`…`interviews/interview81.json`.

### Testing
- Validation JSON automatique exécutée via `python` pour charger tous les fichiers `interviews/interview*.json` et vérifier qu'ils sont bien valides, et le test a réussi.
- Vérification par script que plus aucune interview n'est dépourvue de `processes` ou `subProcesses` (contrôle sur l'ensemble des 81 fichiers), et le test a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699884c8358c832e9a0828dd26bd5951)