### PR TITLE
Retire le logo LFB du header et incrémente la version à 2.14.26

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -87,7 +87,6 @@
         <!-- Header amélioré -->
         <div class="header">
             <div class="header-left">
-                <img src="assets/img/LFB-logo.PNG" alt="LFB - L'engagement éthique" class="header-logo">
                 <div class="header-title">
                     <h1>Cartographie des Risques Corruption</h1>
                     <p>Conformité Loi Sapin 2 - Système de Management Anti-Corruption</p>
@@ -750,7 +749,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.25</span>
+            <span class="app-version">Version 2.14.26</span>
         </footer>
     </div>
 


### PR DESCRIPTION
### Motivation
- Retirer l’affichage du logo LFB depuis l’en-tête de l’application et mettre à jour le numéro de version dans le footer conformément à la règle de versionning par tâche (nouvelle version : `2.14.26`).

### Description
- Modification du fichier `CartoModel.html` : suppression de la balise `<img ... class="header-logo">` dans la section `header-left` et mise à jour du `span` `app-version` de `Version 2.14.25` à `Version 2.14.26`.

### Testing
- Exécutés : `git diff -- CartoModel.html` (OK), démarrage `python3 -m http.server 8000` (OK), capture visuelle via Playwright Chromium (échec), capture visuelle via Playwright Firefox (OK, screenshot généré), et `git show --stat --oneline -1` après commit (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699885edfa1c832ea0c4a951b968aa9c)