### PR TITLE
feat: add simplified two-step risk assessment mode with local save/export

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.3</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.4</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -43,6 +43,9 @@
                 <button class="tab active" onclick="switchTab('dashboard')">
                     📊 Tableau de Bord
                     <span class="tab-badge">0</span>
+                </button>
+                <button class="tab" onclick="switchTab('simple')">
+                    🧭 Version simplifiée
                 </button>
                 <button class="tab" onclick="switchTab('matrix')">
                     📈 Matrice des Risques
@@ -203,6 +206,77 @@
                             </section>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <div id="simple-tab" class="tab-content">
+            <div class="main-content simple-mode">
+                <div class="toolbar">
+                    <div class="toolbar-title">Version simplifiée - Cotation des risques bruts</div>
+                    <div class="toolbar-actions">
+                        <button class="btn btn-outline" id="simpleExportBtn">📤 Export JSON</button>
+                        <button class="btn btn-secondary" id="simpleImportBtn">📥 Import JSON</button>
+                        <input type="file" id="simpleImportFile" accept="application/json" hidden>
+                    </div>
+                </div>
+
+                <div class="content-area simple-mode-content">
+                    <div class="simple-subtabs">
+                        <button class="simple-subtab active" data-simple-view="scenarios">1. Chargement des scénarios</button>
+                        <button class="simple-subtab" data-simple-view="assessment">2. Cotation</button>
+                    </div>
+
+                    <section class="simple-panel active" id="simple-scenarios-panel">
+                        <label class="form-label" for="simpleScenariosInput">Collez vos scénarios (1 ligne = 1 scénario)</label>
+                        <textarea id="simpleScenariosInput" class="form-input simple-textarea" rows="7" placeholder="Exemple :
+Paiement indu via intermédiaire
+Conflit d'intérêt dans la sélection fournisseur
+Cadeau inapproprié à un agent public"></textarea>
+                        <div class="simple-actions-row">
+                            <button class="btn btn-primary" id="simpleLoadScenariosBtn">Charger les scénarios</button>
+                            <span class="simple-helper">Les scénarios remplacent la liste actuelle.</span>
+                        </div>
+                        <div id="simpleScenarioList" class="simple-scenario-list"></div>
+                    </section>
+
+                    <section class="simple-panel" id="simple-assessment-panel">
+                        <div class="simple-sticky-header">
+                            <div>
+                                <div class="simple-caption">Scénario sélectionné</div>
+                                <h3 id="simpleCurrentScenario">Aucun scénario sélectionné</h3>
+                            </div>
+                            <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
+                        </div>
+
+                        <div class="simple-matrix-layout">
+                            <div>
+                                <div class="simple-caption">Matrice de cotation du risque brut</div>
+                                <div class="simple-matrix" id="simpleMatrix"></div>
+                            </div>
+                            <div class="simple-legend-card">
+                                <div class="simple-caption">Légende cotation brute</div>
+                                <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
+                                <div class="simple-legend-sub" id="simpleRawLegendDetail">Déplacez le marqueur pour coter le risque brut.</div>
+                            </div>
+                        </div>
+
+                        <div class="simple-slider-card">
+                            <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
+                            <input type="range" id="simpleEffectiveness" min="0" max="100" value="0">
+                            <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Non évalué</div>
+                        </div>
+
+                        <div class="simple-comment-card">
+                            <label class="form-label" for="simpleComment">Commentaires</label>
+                            <textarea id="simpleComment" class="form-input simple-textarea" rows="4" placeholder="Ajoutez vos observations..."></textarea>
+                        </div>
+
+                        <div class="simple-nav-actions">
+                            <button class="btn btn-secondary" id="simplePrevBtn">← Scénario précédent</button>
+                            <button class="btn btn-primary" id="simpleNextBtn">Scénario suivant →</button>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -588,7 +662,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.3</span>
+            <span class="app-version">Version 2.1.4</span>
         </footer>
     </div>
 
@@ -992,5 +1066,6 @@
     <script defer src="assets/js/rms.core.js"></script>
     <script defer src="assets/js/rms.integrations.js"></script>
     <script defer src="assets/js/main.js"></script>
+    <script defer src="assets/js/simple-mode.js"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2397,3 +2397,169 @@ tbody tr:hover {
     color: #6c7a89;
     margin: 12px 0;
 }
+
+/* Version simplifiée */
+.simple-mode-content {
+    padding: 20px;
+}
+
+.simple-subtabs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.simple-subtab {
+    border: 1px solid #dfe4ea;
+    background: #f9fafb;
+    border-radius: 10px;
+    padding: 10px 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.simple-subtab.active {
+    background: var(--secondary-color);
+    color: #fff;
+}
+
+.simple-panel {
+    display: none;
+}
+
+.simple-panel.active {
+    display: block;
+}
+
+.simple-textarea {
+    width: 100%;
+    resize: vertical;
+}
+
+.simple-actions-row {
+    margin: 12px 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.simple-helper {
+    color: #7b8794;
+    font-size: 0.9em;
+}
+
+.simple-scenario-list {
+    display: grid;
+    gap: 8px;
+}
+
+.simple-scenario-item {
+    text-align: left;
+    border: 1px solid #dfe4ea;
+    background: #fff;
+    border-radius: 10px;
+    padding: 10px;
+    cursor: pointer;
+}
+
+.simple-scenario-item.active {
+    border-color: var(--primary-color);
+    background: #fff9f1;
+}
+
+.simple-empty {
+    padding: 14px;
+    border-radius: 10px;
+    border: 1px dashed #cfd8df;
+    color: #7b8794;
+}
+
+.simple-sticky-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    background: #fff;
+    border: 1px solid #ecf0f1;
+    border-radius: 12px;
+    padding: 14px;
+    margin-bottom: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.simple-caption {
+    font-size: 0.82em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #7b8794;
+    margin-bottom: 5px;
+}
+
+.simple-matrix-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 550px) minmax(240px, 1fr);
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.simple-matrix {
+    margin-top: 8px;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+}
+
+.simple-matrix-cell {
+    min-height: 62px;
+    border: 1px solid #d8e2eb;
+    border-radius: 10px;
+    background: #f8fafc;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.85em;
+    color: #4a5568;
+    padding: 5px;
+}
+
+.simple-marker {
+    font-size: 1.5rem;
+    color: var(--danger-color);
+    line-height: 1;
+    cursor: grab;
+}
+
+.simple-legend-card,
+.simple-slider-card,
+.simple-comment-card {
+    border: 1px solid #ecf0f1;
+    border-radius: 12px;
+    padding: 14px;
+    margin-top: 16px;
+    background: #fff;
+}
+
+.simple-legend-main {
+    font-size: 1.1em;
+    font-weight: 600;
+    margin-bottom: 8px;
+}
+
+.simple-legend-sub {
+    color: #64748b;
+}
+
+.simple-nav-actions {
+    margin-top: 16px;
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+@media (max-width: 980px) {
+    .simple-matrix-layout {
+        grid-template-columns: 1fr;
+    }
+}

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,0 +1,351 @@
+(function () {
+    const STORAGE_KEY = 'rmsSimpleModeData';
+    const DEFAULT_DATA = {
+        version: '2.1.4',
+        scenarios: [],
+        selectedId: null,
+        updatedAt: null
+    };
+
+    const state = {
+        data: structuredClone(DEFAULT_DATA),
+        view: 'scenarios'
+    };
+
+    const dom = {};
+
+    function uid() {
+        return `sc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    function clampMatrixValue(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) return 1;
+        return Math.min(5, Math.max(1, Math.round(num)));
+    }
+
+    function saveLocal() {
+        state.data.updatedAt = new Date().toISOString();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state.data));
+        const lastSave = document.getElementById('lastSaveTime');
+        if (lastSave) {
+            lastSave.textContent = new Date(state.data.updatedAt).toLocaleString('fr-FR');
+        }
+    }
+
+    function loadLocal() {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        try {
+            const parsed = JSON.parse(raw);
+            if (parsed && Array.isArray(parsed.scenarios)) {
+                state.data = {
+                    ...structuredClone(DEFAULT_DATA),
+                    ...parsed,
+                    scenarios: parsed.scenarios.map((s) => ({
+                        id: s.id || uid(),
+                        text: (s.text || '').trim(),
+                        raw: {
+                            prob: clampMatrixValue(s.raw?.prob),
+                            impact: clampMatrixValue(s.raw?.impact)
+                        },
+                        effectiveness: Math.min(100, Math.max(0, Number(s.effectiveness) || 0)),
+                        comment: s.comment || ''
+                    }))
+                };
+            }
+        } catch (err) {
+            console.warn('Impossible de charger la version simplifiée', err);
+        }
+    }
+
+    function getSelectedScenario() {
+        return state.data.scenarios.find((s) => s.id === state.data.selectedId) || null;
+    }
+
+    function selectScenario(id) {
+        state.data.selectedId = id;
+        render();
+        saveLocal();
+    }
+
+    function replaceScenariosFromText(inputText) {
+        const lines = String(inputText || '')
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+
+        state.data.scenarios = lines.map((text) => ({
+            id: uid(),
+            text,
+            raw: { prob: 1, impact: 1 },
+            effectiveness: 0,
+            comment: ''
+        }));
+        state.data.selectedId = state.data.scenarios[0]?.id || null;
+        render();
+        saveLocal();
+    }
+
+    function duplicateScenario() {
+        const current = getSelectedScenario();
+        if (!current) return;
+        const cloned = {
+            ...current,
+            id: uid(),
+            text: `${current.text} (copie)`
+        };
+        const index = state.data.scenarios.findIndex((s) => s.id === current.id);
+        state.data.scenarios.splice(index + 1, 0, cloned);
+        state.data.selectedId = cloned.id;
+        render();
+        saveLocal();
+    }
+
+    function updateCurrentScenario(patch) {
+        const current = getSelectedScenario();
+        if (!current) return;
+        Object.assign(current, patch);
+        saveLocal();
+        renderAssessment();
+    }
+
+    function goToScenario(step) {
+        const scenarios = state.data.scenarios;
+        if (!scenarios.length) return;
+        const index = scenarios.findIndex((s) => s.id === state.data.selectedId);
+        const nextIndex = Math.min(scenarios.length - 1, Math.max(0, index + step));
+        state.data.selectedId = scenarios[nextIndex].id;
+        render();
+        saveLocal();
+    }
+
+    function scoreLabel(score) {
+        if (score >= 20) return 'Critique';
+        if (score >= 12) return 'Élevé';
+        if (score >= 6) return 'Modéré';
+        return 'Faible';
+    }
+
+    function effectivenessLabel(value) {
+        if (value >= 80) return 'Très efficace';
+        if (value >= 60) return 'Efficace';
+        if (value >= 40) return 'Partielle';
+        if (value > 0) return 'Faible';
+        return 'Non évaluée';
+    }
+
+    function renderScenarioList() {
+        dom.scenarioList.innerHTML = '';
+
+        if (!state.data.scenarios.length) {
+            dom.scenarioList.innerHTML = '<div class="simple-empty">Aucun scénario chargé pour le moment.</div>';
+            return;
+        }
+
+        state.data.scenarios.forEach((scenario, index) => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `simple-scenario-item ${scenario.id === state.data.selectedId ? 'active' : ''}`;
+            button.innerHTML = `<span>${index + 1}. ${scenario.text}</span>`;
+            button.addEventListener('click', () => selectScenario(scenario.id));
+            dom.scenarioList.appendChild(button);
+        });
+    }
+
+    function renderMatrix() {
+        dom.matrix.innerHTML = '';
+        for (let impact = 5; impact >= 1; impact -= 1) {
+            for (let prob = 1; prob <= 5; prob += 1) {
+                const cell = document.createElement('div');
+                cell.className = 'simple-matrix-cell';
+                cell.dataset.prob = String(prob);
+                cell.dataset.impact = String(impact);
+                cell.innerHTML = `<span>P${prob}×I${impact}</span>`;
+                cell.addEventListener('dragover', (evt) => evt.preventDefault());
+                cell.addEventListener('drop', (evt) => {
+                    evt.preventDefault();
+                    updateCurrentScenario({ raw: { prob, impact } });
+                });
+                cell.addEventListener('click', () => updateCurrentScenario({ raw: { prob, impact } }));
+                dom.matrix.appendChild(cell);
+            }
+        }
+
+        const marker = document.createElement('div');
+        marker.id = 'simpleMatrixMarker';
+        marker.className = 'simple-marker';
+        marker.draggable = true;
+        marker.title = 'Glissez-déposez ce marqueur dans une autre case';
+        marker.textContent = '⬤';
+        marker.addEventListener('dragstart', (evt) => {
+            evt.dataTransfer.setData('text/plain', 'marker');
+        });
+
+        dom.matrix.appendChild(marker);
+    }
+
+    function renderAssessment() {
+        const scenario = getSelectedScenario();
+        const disabled = !scenario;
+
+        dom.currentScenario.textContent = scenario ? scenario.text : 'Aucun scénario sélectionné';
+        dom.duplicateBtn.disabled = disabled;
+        dom.prevBtn.disabled = disabled;
+        dom.nextBtn.disabled = disabled;
+        dom.effectiveness.disabled = disabled;
+        dom.comment.disabled = disabled;
+
+        if (!scenario) {
+            dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
+            dom.rawLegendDetail.textContent = 'Chargez des scénarios pour commencer la cotation.';
+            dom.effectiveness.value = 0;
+            dom.effectivenessLegend.textContent = '0% - Non évaluée';
+            dom.comment.value = '';
+            return;
+        }
+
+        const { prob, impact } = scenario.raw;
+        const score = prob * impact;
+        dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
+        dom.rawLegendDetail.textContent = `Probabilité: ${prob}/5 • Impact: ${impact}/5`;
+
+        const marker = document.getElementById('simpleMatrixMarker');
+        const cellIndex = (5 - impact) * 5 + (prob - 1);
+        const targetCell = dom.matrix.children[cellIndex];
+        if (marker && targetCell) {
+            targetCell.appendChild(marker);
+        }
+
+        dom.effectiveness.value = scenario.effectiveness;
+        dom.effectivenessLegend.textContent = `${scenario.effectiveness}% - ${effectivenessLabel(scenario.effectiveness)}`;
+        dom.comment.value = scenario.comment;
+
+        const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
+        dom.prevBtn.disabled = idx <= 0;
+        dom.nextBtn.disabled = idx >= state.data.scenarios.length - 1;
+    }
+
+    function setView(viewName) {
+        state.view = viewName;
+        document.querySelectorAll('.simple-subtab').forEach((btn) => {
+            btn.classList.toggle('active', btn.dataset.simpleView === viewName);
+        });
+        dom.scenariosPanel.classList.toggle('active', viewName === 'scenarios');
+        dom.assessmentPanel.classList.toggle('active', viewName === 'assessment');
+    }
+
+    function exportData() {
+        const payload = JSON.stringify(state.data, null, 2);
+        const blob = new Blob([payload], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `cartographie-simplifiee-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function importDataFromFile(file) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const parsed = JSON.parse(String(reader.result || '{}'));
+                if (!parsed || !Array.isArray(parsed.scenarios)) {
+                    throw new Error('Format JSON invalide');
+                }
+                state.data = structuredClone(DEFAULT_DATA);
+                state.data.version = parsed.version || DEFAULT_DATA.version;
+                state.data.scenarios = parsed.scenarios.map((s) => ({
+                    id: s.id || uid(),
+                    text: (s.text || '').trim(),
+                    raw: {
+                        prob: clampMatrixValue(s.raw?.prob),
+                        impact: clampMatrixValue(s.raw?.impact)
+                    },
+                    effectiveness: Math.min(100, Math.max(0, Number(s.effectiveness) || 0)),
+                    comment: s.comment || ''
+                })).filter((s) => s.text);
+                state.data.selectedId = parsed.selectedId && state.data.scenarios.some((s) => s.id === parsed.selectedId)
+                    ? parsed.selectedId
+                    : state.data.scenarios[0]?.id || null;
+                render();
+                saveLocal();
+            } catch (error) {
+                alert(`Import impossible: ${error.message}`);
+            }
+        };
+        reader.readAsText(file);
+    }
+
+    function bindEvents() {
+        document.querySelectorAll('.simple-subtab').forEach((btn) => {
+            btn.addEventListener('click', () => setView(btn.dataset.simpleView));
+        });
+
+        dom.loadScenariosBtn.addEventListener('click', () => replaceScenariosFromText(dom.scenariosInput.value));
+        dom.duplicateBtn.addEventListener('click', duplicateScenario);
+        dom.prevBtn.addEventListener('click', () => goToScenario(-1));
+        dom.nextBtn.addEventListener('click', () => goToScenario(1));
+
+        dom.effectiveness.addEventListener('input', (evt) => {
+            const value = Number(evt.target.value) || 0;
+            updateCurrentScenario({ effectiveness: value });
+        });
+
+        dom.comment.addEventListener('input', (evt) => {
+            updateCurrentScenario({ comment: evt.target.value });
+        });
+
+        dom.exportBtn.addEventListener('click', exportData);
+        dom.importBtn.addEventListener('click', () => dom.importFile.click());
+        dom.importFile.addEventListener('change', (evt) => {
+            importDataFromFile(evt.target.files[0]);
+            evt.target.value = '';
+        });
+    }
+
+    function render() {
+        renderScenarioList();
+        renderAssessment();
+    }
+
+    function init() {
+        dom.scenariosInput = document.getElementById('simpleScenariosInput');
+        dom.loadScenariosBtn = document.getElementById('simpleLoadScenariosBtn');
+        dom.scenarioList = document.getElementById('simpleScenarioList');
+        dom.scenariosPanel = document.getElementById('simple-scenarios-panel');
+        dom.assessmentPanel = document.getElementById('simple-assessment-panel');
+        dom.currentScenario = document.getElementById('simpleCurrentScenario');
+        dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
+        dom.matrix = document.getElementById('simpleMatrix');
+        dom.rawLegend = document.getElementById('simpleRawLegend');
+        dom.rawLegendDetail = document.getElementById('simpleRawLegendDetail');
+        dom.effectiveness = document.getElementById('simpleEffectiveness');
+        dom.effectivenessLegend = document.getElementById('simpleEffectivenessLegend');
+        dom.comment = document.getElementById('simpleComment');
+        dom.prevBtn = document.getElementById('simplePrevBtn');
+        dom.nextBtn = document.getElementById('simpleNextBtn');
+        dom.exportBtn = document.getElementById('simpleExportBtn');
+        dom.importBtn = document.getElementById('simpleImportBtn');
+        dom.importFile = document.getElementById('simpleImportFile');
+
+        if (!dom.scenariosInput || !dom.matrix) {
+            return;
+        }
+
+        loadLocal();
+
+        if (!state.data.selectedId && state.data.scenarios.length) {
+            state.data.selectedId = state.data.scenarios[0].id;
+        }
+
+        renderMatrix();
+        bindEvents();
+        setView('scenarios');
+        render();
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
### Motivation
- Fournir une version simplifiée de l'outil de cartographie pour une cotation rapide des risques bruts en deux étapes (chargement des scénarios puis cotation) avec sauvegarde locale et export/import JSON.
- Permettre un flux léger avec affichage fixe du scénario sélectionné, drag & drop pour coter le risque brut, et conservation des évaluations pour itération rapide.

### Description
- Ajout d'un nouvel onglet principal `Version simplifiée` avec deux vues internes : `Chargement des scénarios` (coller un texte multi‑lignes, 1 ligne = 1 scénario) et `Cotation` (UI sticky, matrice P×I, marqueur draggable/clic, légende dynamique). (`CartoModel.html`, `assets/js/simple-mode.js`, `assets/css/main.css`).
- Implémentation d'un workflow complet : duplication de scénario, navigation `Précédent`/`Suivant`, slider d'efficacité avec légende dynamique et champ commentaire multi‑lignes. (`assets/js/simple-mode.js`).
- Persistance automatique dans `localStorage` (`rmsSimpleModeData`) et possibilités d'`export` / `import` JSON pour restaurer scénarios, cotations et sélection. (`assets/js/simple-mode.js`).
- Ajout de styles dédiés responsive pour la version simplifiée et insertion du script `assets/js/simple-mode.js` dans le HTML. (`assets/css/main.css`, `CartoModel.html`).
- Mise à jour du libellé de version affiché dans le titre et le footer à `2.1.4` conformément à la consigne de versionnage visible dans l'UI. (`CartoModel.html`).

### Testing
- Vérification de la syntaxe JavaScript avec `node --check assets/js/simple-mode.js` — réussite.
- Vérification basique des diffs avec `git diff --check` — réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f5309174832ebae3a7218e928053)