### PR TITLE
Fix simple mode UX initialization fallback and bump version to 2.1.5

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.4</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.5</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -662,7 +662,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.4</span>
+            <span class="app-version">Version 2.1.5</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,18 +1,25 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.4',
+        version: '2.1.5',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
 
     const state = {
-        data: structuredClone(DEFAULT_DATA),
+        data: cloneData(DEFAULT_DATA),
         view: 'scenarios'
     };
 
     const dom = {};
+
+    function cloneData(data) {
+        if (typeof structuredClone === 'function') {
+            return structuredClone(data);
+        }
+        return JSON.parse(JSON.stringify(data));
+    }
 
     function uid() {
         return `sc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -40,7 +47,7 @@
             const parsed = JSON.parse(raw);
             if (parsed && Array.isArray(parsed.scenarios)) {
                 state.data = {
-                    ...structuredClone(DEFAULT_DATA),
+                    ...cloneData(DEFAULT_DATA),
                     ...parsed,
                     scenarios: parsed.scenarios.map((s) => ({
                         id: s.id || uid(),
@@ -255,7 +262,7 @@
                 if (!parsed || !Array.isArray(parsed.scenarios)) {
                     throw new Error('Format JSON invalide');
                 }
-                state.data = structuredClone(DEFAULT_DATA);
+                state.data = cloneData(DEFAULT_DATA);
                 state.data.version = parsed.version || DEFAULT_DATA.version;
                 state.data.scenarios = parsed.scenarios.map((s) => ({
                     id: s.id || uid(),


### PR DESCRIPTION
### Motivation
- La version simplifiée pouvait ne pas s'initialiser correctement dans certains environnements faute de `structuredClone`, ce qui provoquait un rendu UX différent du reste de l'application.  
- Le numéro de version dans le footer et les métadonnées devait être incrémenté conformément à la consigne de mise à jour de version pour chaque tâche.

### Description
- Ajout d'une fonction `cloneData` dans `assets/js/simple-mode.js` qui utilise `structuredClone` si disponible et retombe sur `JSON.parse(JSON.stringify(...))` sinon.  
- Remplacement des usages directs de `structuredClone` par `cloneData` pour l'initialisation de l'état, le chargement local (`loadLocal`) et l'import JSON (`importDataFromFile`).  
- Incrémentation de la version à `2.1.5` dans `assets/js/simple-mode.js` et dans `CartoModel.html` (titre et footer) pour refléter le changement.

### Testing
- Vérification de syntaxe JS via `node --check assets/js/simple-mode.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f887567c832eb07585e6b5ff7978)