### PR TITLE
Simple mode: switch risk matrix to 4×4, UI/legend updates and bump to v2.1.6

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.5</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.6</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -249,22 +249,41 @@ Cadeau inapproprié à un agent public"></textarea>
                             <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
                         </div>
 
-                        <div class="simple-matrix-layout">
-                            <div>
-                                <div class="simple-caption">Matrice de cotation du risque brut</div>
-                                <div class="simple-matrix" id="simpleMatrix"></div>
+                        <div class="risk-matrix-editor simple-risk-matrix-editor">
+                            <div class="risk-matrix-layout">
+                                <div class="edit-matrix-container">
+                                    <div class="matrix edit-matrix simple-edit-matrix">
+                                        <div class="matrix-grid" id="simpleMatrix"></div>
+                                        <div class="axis-label x-axis">Probabilité →</div>
+                                        <div class="axis-label y-axis">
+                                            <span class="axis-text">Impact</span>
+                                            <span class="axis-arrow" aria-hidden="true">↑</span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="matrix-description simple-matrix-description">
+                                    <div class="matrix-description-header">Risque Brut aggravé</div>
+                                    <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
+                                    <div class="simple-legend-sub" id="simpleRawLegendDetail">Sélectionnez une case pour afficher la cotation détaillée.</div>
+                                    <div class="simple-effectiveness-block">
+                                        <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
+                                        <input type="range" id="simpleEffectiveness" min="0" max="100" step="5" value="0">
+                                        <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Non évaluée</div>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="simple-legend-card">
-                                <div class="simple-caption">Légende cotation brute</div>
-                                <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
-                                <div class="simple-legend-sub" id="simpleRawLegendDetail">Déplacez le marqueur pour coter le risque brut.</div>
+                            <div class="risk-score-cards simple-score-cards">
+                                <div class="risk-score-card brut active">
+                                    <div class="risk-score-title">Risque Brut</div>
+                                    <div class="risk-score-value" id="simpleRawScoreValue">Score: 1</div>
+                                    <div class="risk-score-meta" id="simpleRawCoordValue">P1 × I1</div>
+                                </div>
+                                <div class="risk-score-card net">
+                                    <div class="risk-score-title">Mesures de maîtrise</div>
+                                    <div class="risk-score-value" id="simpleEffectivenessValue">0%</div>
+                                    <div class="risk-score-meta" id="simpleEffectivenessMeta">Non évaluée</div>
+                                </div>
                             </div>
-                        </div>
-
-                        <div class="simple-slider-card">
-                            <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
-                            <input type="range" id="simpleEffectiveness" min="0" max="100" value="0">
-                            <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Non évalué</div>
                         </div>
 
                         <div class="simple-comment-card">
@@ -662,7 +681,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.5</span>
+            <span class="app-version">Version 2.1.6</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2507,28 +2507,22 @@ tbody tr:hover {
 .simple-matrix {
     margin-top: 8px;
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
-    gap: 8px;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    gap: 0;
 }
 
 .simple-matrix-cell {
-    min-height: 62px;
-    border: 1px solid #d8e2eb;
-    border-radius: 10px;
-    background: #f8fafc;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.85em;
-    color: #4a5568;
-    padding: 5px;
+    min-height: unset;
 }
 
 .simple-marker {
-    font-size: 1.5rem;
-    color: var(--danger-color);
-    line-height: 1;
+    position: static;
+    font-size: 0.9rem;
+    width: 30px;
+    height: 30px;
     cursor: grab;
+    margin: auto;
 }
 
 .simple-legend-card,
@@ -2556,6 +2550,28 @@ tbody tr:hover {
     display: flex;
     justify-content: space-between;
     gap: 12px;
+}
+
+.simple-risk-matrix-editor {
+    margin-top: 0;
+}
+
+.simple-edit-matrix {
+    width: min(500px, 100%);
+}
+
+.simple-matrix-description {
+    background: #f7f9fb;
+}
+
+.simple-effectiveness-block {
+    border-top: 1px solid #dde5ec;
+    padding-top: 12px;
+    margin-top: 4px;
+}
+
+.simple-score-cards {
+    margin-top: -2px;
 }
 
 @media (max-width: 980px) {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.5',
+        version: '2.1.6',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -28,7 +28,14 @@
     function clampMatrixValue(value) {
         const num = Number(value);
         if (!Number.isFinite(num)) return 1;
-        return Math.min(5, Math.max(1, Math.round(num)));
+        return Math.min(4, Math.max(1, Math.round(num)));
+    }
+
+    function scoreToLevel(score) {
+        if (score >= 13) return 4;
+        if (score >= 9) return 3;
+        if (score >= 5) return 2;
+        return 1;
     }
 
     function saveLocal() {
@@ -162,13 +169,13 @@
 
     function renderMatrix() {
         dom.matrix.innerHTML = '';
-        for (let impact = 5; impact >= 1; impact -= 1) {
-            for (let prob = 1; prob <= 5; prob += 1) {
+        for (let impact = 4; impact >= 1; impact -= 1) {
+            for (let prob = 1; prob <= 4; prob += 1) {
                 const cell = document.createElement('div');
-                cell.className = 'simple-matrix-cell';
+                const score = prob * impact;
+                cell.className = `matrix-cell simple-matrix-cell level-${scoreToLevel(score)}`;
                 cell.dataset.prob = String(prob);
                 cell.dataset.impact = String(impact);
-                cell.innerHTML = `<span>P${prob}×I${impact}</span>`;
                 cell.addEventListener('dragover', (evt) => evt.preventDefault());
                 cell.addEventListener('drop', (evt) => {
                     evt.preventDefault();
@@ -181,10 +188,10 @@
 
         const marker = document.createElement('div');
         marker.id = 'simpleMatrixMarker';
-        marker.className = 'simple-marker';
+        marker.className = 'simple-marker risk-point brut';
         marker.draggable = true;
         marker.title = 'Glissez-déposez ce marqueur dans une autre case';
-        marker.textContent = '⬤';
+        marker.textContent = 'B';
         marker.addEventListener('dragstart', (evt) => {
             evt.dataTransfer.setData('text/plain', 'marker');
         });
@@ -208,6 +215,10 @@
             dom.rawLegendDetail.textContent = 'Chargez des scénarios pour commencer la cotation.';
             dom.effectiveness.value = 0;
             dom.effectivenessLegend.textContent = '0% - Non évaluée';
+            dom.rawScoreValue.textContent = 'Score: 1';
+            dom.rawCoordValue.textContent = 'P1 × I1';
+            dom.effectivenessValue.textContent = '0%';
+            dom.effectivenessMeta.textContent = 'Non évaluée';
             dom.comment.value = '';
             return;
         }
@@ -215,10 +226,12 @@
         const { prob, impact } = scenario.raw;
         const score = prob * impact;
         dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
-        dom.rawLegendDetail.textContent = `Probabilité: ${prob}/5 • Impact: ${impact}/5`;
+        dom.rawLegendDetail.textContent = `Probabilité: ${prob}/4 • Impact: ${impact}/4`;
+        dom.rawScoreValue.textContent = `Score: ${score}`;
+        dom.rawCoordValue.textContent = `P${prob} × I${impact}`;
 
         const marker = document.getElementById('simpleMatrixMarker');
-        const cellIndex = (5 - impact) * 5 + (prob - 1);
+        const cellIndex = (4 - impact) * 4 + (prob - 1);
         const targetCell = dom.matrix.children[cellIndex];
         if (marker && targetCell) {
             targetCell.appendChild(marker);
@@ -226,6 +239,8 @@
 
         dom.effectiveness.value = scenario.effectiveness;
         dom.effectivenessLegend.textContent = `${scenario.effectiveness}% - ${effectivenessLabel(scenario.effectiveness)}`;
+        dom.effectivenessValue.textContent = `${scenario.effectiveness}%`;
+        dom.effectivenessMeta.textContent = effectivenessLabel(scenario.effectiveness);
         dom.comment.value = scenario.comment;
 
         const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
@@ -331,6 +346,10 @@
         dom.rawLegendDetail = document.getElementById('simpleRawLegendDetail');
         dom.effectiveness = document.getElementById('simpleEffectiveness');
         dom.effectivenessLegend = document.getElementById('simpleEffectivenessLegend');
+        dom.rawScoreValue = document.getElementById('simpleRawScoreValue');
+        dom.rawCoordValue = document.getElementById('simpleRawCoordValue');
+        dom.effectivenessValue = document.getElementById('simpleEffectivenessValue');
+        dom.effectivenessMeta = document.getElementById('simpleEffectivenessMeta');
         dom.comment = document.getElementById('simpleComment');
         dom.prevBtn = document.getElementById('simplePrevBtn');
         dom.nextBtn = document.getElementById('simpleNextBtn');


### PR DESCRIPTION
### Motivation
- Bump the app version to `2.1.6` and align the simple-mode UI to a simplified 4×4 risk matrix. 
- Improve the simple-mode risk editor UX by replacing the old grid with a clearer matrix editor, clearer legend, and dedicated score/effectiveness display. 
- Ensure stored simple-mode data reflects the new version and matrix scale. 

### Description
- Updated `CartoModel.html` to change the displayed application version to `2.1.6` and replace the previous simple-mode matrix markup with a new `risk-matrix-editor` structure and new legend/score card elements. 
- Adjusted CSS in `assets/css/main.css` to change the grid sizing and layout for the simple matrix, add styling for the new editor, and update marker sizing and positioning. 
- Modified `assets/js/simple-mode.js` to set `DEFAULT_DATA.version` to `2.1.6`, change `clampMatrixValue` maximum from `5` to `4`, add a new `scoreToLevel` mapping, and update `renderMatrix` and related logic to build a 4×4 grid (probabilities and impacts run 1..4) with cell `level-*` classes. 
- Updated marker behavior, marker content, cell indexing calculation, legend text, and wired new DOM elements for `simpleRawScoreValue`, `simpleRawCoordValue`, `simpleEffectivenessValue`, and `simpleEffectivenessMeta`. 

### Testing
- No automated tests were added or available for the UI changes in this patch, and no automated test suite was run against these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f96825d4832eb8ee5454194abe7a)