### PR TITLE
Simplified mode UX: 500-char scenarios, discrete slider, flashy matrix colors, version 2.1.8

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.7</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.8</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -228,7 +228,7 @@
                     </div>
 
                     <section class="simple-panel active" id="simple-scenarios-panel">
-                        <label class="form-label" for="simpleScenariosInput">Collez vos scénarios (1 ligne = 1 scénario)</label>
+                        <label class="form-label" for="simpleScenariosInput">Collez vos scénarios (1 ligne = 1 scénario, max. 500 caractères)</label>
                         <textarea id="simpleScenariosInput" class="form-input simple-textarea" rows="7" placeholder="Exemple :
 Paiement indu via intermédiaire
 Conflit d'intérêt dans la sélection fournisseur
@@ -244,7 +244,7 @@ Cadeau inapproprié à un agent public"></textarea>
                         <div class="simple-sticky-header">
                             <div>
                                 <div class="simple-caption">Scénario sélectionné</div>
-                                <h3 id="simpleCurrentScenario">Aucun scénario sélectionné</h3>
+                                <h3 id="simpleCurrentScenario" class="simple-current-scenario">Aucun scénario sélectionné</h3>
                             </div>
                             <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
                         </div>
@@ -262,7 +262,7 @@ Cadeau inapproprié à un agent public"></textarea>
                                     </div>
                                 </div>
                                 <div class="matrix-description simple-matrix-description">
-                                    <div class="matrix-description-header">Risque Brut aggravé</div>
+                                    <div class="matrix-description-header">Risque brut</div>
                                     <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
                                     <div class="simple-legend-sub" id="simpleRawLegendDetail">Sélectionnez une case pour afficher la cotation détaillée.</div>
                                     <div class="simple-legend-description">
@@ -282,18 +282,6 @@ Cadeau inapproprié à un agent public"></textarea>
                                 <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
                                 <input type="range" id="simpleEffectiveness" min="0" max="100" step="5" value="0">
                                 <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Non évaluée</div>
-                            </div>
-                            <div class="risk-score-cards simple-score-cards">
-                                <div class="risk-score-card brut active">
-                                    <div class="risk-score-title">Risque Brut</div>
-                                    <div class="risk-score-value" id="simpleRawScoreValue">Score: 1</div>
-                                    <div class="risk-score-meta" id="simpleRawCoordValue">P1 × I1</div>
-                                </div>
-                                <div class="risk-score-card net">
-                                    <div class="risk-score-title">Mesures de maîtrise</div>
-                                    <div class="risk-score-value" id="simpleEffectivenessValue">0%</div>
-                                    <div class="risk-score-meta" id="simpleEffectivenessMeta">Non évaluée</div>
-                                </div>
                             </div>
                         </div>
 
@@ -395,19 +383,19 @@ Cadeau inapproprié à un agent public"></textarea>
 
                         <div class="legend">
                             <div class="legend-item">
-                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(46, 204, 113, 0.4), rgba(46, 204, 113, 0.6));"></div>
+                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(0, 255, 163, 0.55), rgba(0, 196, 133, 0.85));"></div>
                                 <span>Acceptable (1-4)</span>
                             </div>
                             <div class="legend-item">
-                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(241, 196, 15, 0.4), rgba(241, 196, 15, 0.6));"></div>
+                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(255, 236, 69, 0.6), rgba(255, 184, 0, 0.88));"></div>
                                 <span>Modéré (5-8)</span>
                             </div>
                             <div class="legend-item">
-                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(230, 126, 34, 0.4), rgba(230, 126, 34, 0.6));"></div>
+                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(255, 165, 77, 0.62), rgba(255, 107, 0, 0.9));"></div>
                                 <span>Élevé (9-12)</span>
                             </div>
                             <div class="legend-item">
-                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(231, 76, 60, 0.5), rgba(231, 76, 60, 0.7));"></div>
+                                <div class="legend-color" style="background: linear-gradient(135deg, rgba(255, 102, 132, 0.68), rgba(255, 0, 72, 0.92));"></div>
                                 <span>Critique (13-16)</span>
                             </div>
                         </div>
@@ -692,7 +680,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.7</span>
+            <span class="app-version">Version 2.1.8</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -433,10 +433,10 @@ body {
     box-shadow: inset 0 0 20px rgba(0,0,0,0.1);
 }
 
-.matrix-cell.level-1 { background: linear-gradient(135deg, rgba(46, 204, 113, 0.2), rgba(46, 204, 113, 0.4)); }
-.matrix-cell.level-2 { background: linear-gradient(135deg, rgba(241, 196, 15, 0.2), rgba(241, 196, 15, 0.4)); }
-.matrix-cell.level-3 { background: linear-gradient(135deg, rgba(230, 126, 34, 0.2), rgba(230, 126, 34, 0.4)); }
-.matrix-cell.level-4 { background: linear-gradient(135deg, rgba(231, 76, 60, 0.3), rgba(231, 76, 60, 0.5)); }
+.matrix-cell.level-1 { background: linear-gradient(135deg, rgba(0, 255, 163, 0.35), rgba(0, 196, 133, 0.62)); }
+.matrix-cell.level-2 { background: linear-gradient(135deg, rgba(255, 236, 69, 0.4), rgba(255, 184, 0, 0.68)); }
+.matrix-cell.level-3 { background: linear-gradient(135deg, rgba(255, 165, 77, 0.45), rgba(255, 107, 0, 0.7)); }
+.matrix-cell.level-4 { background: linear-gradient(135deg, rgba(255, 102, 132, 0.5), rgba(255, 0, 72, 0.75)); }
 
 .risk-point {
     position: absolute;
@@ -2497,6 +2497,15 @@ tbody tr:hover {
     margin-bottom: 5px;
 }
 
+.simple-current-scenario {
+    margin: 0;
+    max-width: 100%;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.35;
+    min-height: 3.2em;
+}
+
 .simple-matrix-layout {
     display: grid;
     grid-template-columns: minmax(280px, 550px) minmax(240px, 1fr);
@@ -2573,24 +2582,27 @@ tbody tr:hover {
 }
 
 .simple-edit-matrix .simple-matrix-cell.level-1 {
-    background: #a6d8bc;
+    background: linear-gradient(135deg, #4dffc1, #08d191);
 }
 
 .simple-edit-matrix .simple-matrix-cell.level-2 {
-    background: #e8dba3;
+    background: linear-gradient(135deg, #fff066, #ffbf1f);
 }
 
 .simple-edit-matrix .simple-matrix-cell.level-3 {
-    background: #e7ccad;
+    background: linear-gradient(135deg, #ffc27a, #ff8734);
 }
 
 .simple-edit-matrix .simple-matrix-cell.level-4 {
-    background: #e4aca6;
+    background: linear-gradient(135deg, #ff8aa6, #ff355f);
 }
 
 .simple-edit-matrix .simple-marker {
-    border: 2px solid #dbe9f5;
-    box-shadow: 0 0 0 4px rgba(53, 138, 199, 0.18), 0 4px 10px rgba(0, 0, 0, 0.2);
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28);
+    color: #ffffff;
+    font-size: 1.5rem;
+    line-height: 1;
 }
 
 .simple-edit-matrix .axis-label {
@@ -2639,10 +2651,6 @@ tbody tr:hover {
     padding: 14px;
     margin-top: 10px;
     background: #fff;
-}
-
-.simple-score-cards {
-    margin-top: -2px;
 }
 
 @media (max-width: 980px) {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,11 +1,19 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.7',
+        version: '2.1.8',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
+    const MAX_SCENARIO_LENGTH = 500;
+    const EFFECTIVENESS_LEVELS = [
+        { value: 0, label: 'Non évaluée' },
+        { value: 25, label: 'Faible' },
+        { value: 50, label: 'Partielle' },
+        { value: 75, label: 'Efficace' },
+        { value: 100, label: 'Très efficace' }
+    ];
     const PROBABILITY_LEGEND = {
         1: {
             title: 'Probabilité 1 – Peu probable',
@@ -67,6 +75,17 @@
         return Math.min(4, Math.max(1, Math.round(num)));
     }
 
+    function normalizeScenarioText(value) {
+        return String(value || '').trim().slice(0, MAX_SCENARIO_LENGTH);
+    }
+
+    function nearestEffectivenessLevel(value) {
+        const numeric = Math.min(100, Math.max(0, Number(value) || 0));
+        return EFFECTIVENESS_LEVELS.reduce((closest, level) => (
+            Math.abs(level.value - numeric) < Math.abs(closest.value - numeric) ? level : closest
+        ), EFFECTIVENESS_LEVELS[0]).value;
+    }
+
     function scoreToLevel(score) {
         if (score >= 13) return 4;
         if (score >= 9) return 3;
@@ -94,12 +113,12 @@
                     ...parsed,
                     scenarios: parsed.scenarios.map((s) => ({
                         id: s.id || uid(),
-                        text: (s.text || '').trim(),
+                        text: normalizeScenarioText(s.text),
                         raw: {
                             prob: clampMatrixValue(s.raw?.prob),
                             impact: clampMatrixValue(s.raw?.impact)
                         },
-                        effectiveness: Math.min(100, Math.max(0, Number(s.effectiveness) || 0)),
+                        effectiveness: nearestEffectivenessLevel(s.effectiveness),
                         comment: s.comment || ''
                     }))
                 };
@@ -122,14 +141,14 @@
     function replaceScenariosFromText(inputText) {
         const lines = String(inputText || '')
             .split(/\r?\n/)
-            .map((line) => line.trim())
+            .map((line) => normalizeScenarioText(line))
             .filter(Boolean);
 
         state.data.scenarios = lines.map((text) => ({
             id: uid(),
             text,
             raw: { prob: 1, impact: 1 },
-            effectiveness: 0,
+            effectiveness: EFFECTIVENESS_LEVELS[0].value,
             comment: ''
         }));
         state.data.selectedId = state.data.scenarios[0]?.id || null;
@@ -178,11 +197,7 @@
     }
 
     function effectivenessLabel(value) {
-        if (value >= 80) return 'Très efficace';
-        if (value >= 60) return 'Efficace';
-        if (value >= 40) return 'Partielle';
-        if (value > 0) return 'Faible';
-        return 'Non évaluée';
+        return EFFECTIVENESS_LEVELS.find((level) => level.value === nearestEffectivenessLevel(value))?.label || 'Non évaluée';
     }
 
     function renderScenarioList() {
@@ -227,7 +242,7 @@
         marker.className = 'simple-marker risk-point brut';
         marker.draggable = true;
         marker.title = 'Glissez-déposez ce marqueur dans une autre case';
-        marker.textContent = 'B';
+        marker.textContent = '•';
         marker.addEventListener('dragstart', (evt) => {
             evt.dataTransfer.setData('text/plain', 'marker');
         });
@@ -252,10 +267,6 @@
             renderLegendDescription(1, 1);
             dom.effectiveness.value = 0;
             dom.effectivenessLegend.textContent = '0% - Non évaluée';
-            dom.rawScoreValue.textContent = 'Score: 1';
-            dom.rawCoordValue.textContent = 'P1 × I1';
-            dom.effectivenessValue.textContent = '0%';
-            dom.effectivenessMeta.textContent = 'Non évaluée';
             dom.comment.value = '';
             return;
         }
@@ -265,9 +276,6 @@
         dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
         dom.rawLegendDetail.textContent = `Probabilité: ${prob}/4 • Impact: ${impact}/4`;
         renderLegendDescription(prob, impact);
-        dom.rawScoreValue.textContent = `Score: ${score}`;
-        dom.rawCoordValue.textContent = `P${prob} × I${impact}`;
-
         const marker = document.getElementById('simpleMatrixMarker');
         const cellIndex = (4 - impact) * 4 + (prob - 1);
         const targetCell = dom.matrix.children[cellIndex];
@@ -275,10 +283,12 @@
             targetCell.appendChild(marker);
         }
 
-        dom.effectiveness.value = scenario.effectiveness;
-        dom.effectivenessLegend.textContent = `${scenario.effectiveness}% - ${effectivenessLabel(scenario.effectiveness)}`;
-        dom.effectivenessValue.textContent = `${scenario.effectiveness}%`;
-        dom.effectivenessMeta.textContent = effectivenessLabel(scenario.effectiveness);
+        const snappedEffectiveness = nearestEffectivenessLevel(scenario.effectiveness);
+        if (snappedEffectiveness !== scenario.effectiveness) {
+            scenario.effectiveness = snappedEffectiveness;
+        }
+        dom.effectiveness.value = snappedEffectiveness;
+        dom.effectivenessLegend.textContent = `${snappedEffectiveness}% - ${effectivenessLabel(snappedEffectiveness)}`;
         dom.comment.value = scenario.comment;
 
         const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
@@ -338,12 +348,12 @@
                 state.data.version = parsed.version || DEFAULT_DATA.version;
                 state.data.scenarios = parsed.scenarios.map((s) => ({
                     id: s.id || uid(),
-                    text: (s.text || '').trim(),
+                    text: normalizeScenarioText(s.text),
                     raw: {
                         prob: clampMatrixValue(s.raw?.prob),
                         impact: clampMatrixValue(s.raw?.impact)
                     },
-                    effectiveness: Math.min(100, Math.max(0, Number(s.effectiveness) || 0)),
+                    effectiveness: nearestEffectivenessLevel(s.effectiveness),
                     comment: s.comment || ''
                 })).filter((s) => s.text);
                 state.data.selectedId = parsed.selectedId && state.data.scenarios.some((s) => s.id === parsed.selectedId)
@@ -369,7 +379,8 @@
         dom.nextBtn.addEventListener('click', () => goToScenario(1));
 
         dom.effectiveness.addEventListener('input', (evt) => {
-            const value = Number(evt.target.value) || 0;
+            const value = nearestEffectivenessLevel(evt.target.value);
+            evt.target.value = value;
             updateCurrentScenario({ effectiveness: value });
         });
 
@@ -407,11 +418,10 @@
         dom.legendImpactTitle = document.getElementById('simpleLegendImpactTitle');
         dom.legendImpactBullets = document.getElementById('simpleLegendImpactBullets');
         dom.effectiveness = document.getElementById('simpleEffectiveness');
+        dom.effectiveness.min = String(EFFECTIVENESS_LEVELS[0].value);
+        dom.effectiveness.max = String(EFFECTIVENESS_LEVELS[EFFECTIVENESS_LEVELS.length - 1].value);
+        dom.effectiveness.step = '1';
         dom.effectivenessLegend = document.getElementById('simpleEffectivenessLegend');
-        dom.rawScoreValue = document.getElementById('simpleRawScoreValue');
-        dom.rawCoordValue = document.getElementById('simpleRawCoordValue');
-        dom.effectivenessValue = document.getElementById('simpleEffectivenessValue');
-        dom.effectivenessMeta = document.getElementById('simpleEffectivenessMeta');
         dom.comment = document.getElementById('simpleComment');
         dom.prevBtn = document.getElementById('simplePrevBtn');
         dom.nextBtn = document.getElementById('simpleNextBtn');


### PR DESCRIPTION
### Motivation
- Permettre des scénarios plus longs et lisibles en version simplifiée en limitant chaque scénario à 500 caractères et en améliorant l'affichage multi‑ligne.  
- Marquer visuellement la position d’un risque sur la matrice avec une puce claire et rendre les zones de la matrice plus visibles en utilisant des couleurs plus flashy.  
- Harmoniser le libellé de la légende en remplaçant «Risque Brut aggravé» par «Risque brut» et retirer le petit bloc de cartes demandé en pièce jointe.  
- Aligner le slider de maîtrise sur des niveaux discrets de l’échelle et mettre à jour la version de l’application à `2.1.8` (titre, footer et données par défaut).  

### Description
- Mise à jour de la version à `2.1.8` dans `CartoModel.html` (titre + footer) et dans `assets/js/simple-mode.js` (`DEFAULT_DATA.version`).  
- Limitation des scénarios à 500 caractères avec ajout de `MAX_SCENARIO_LENGTH` et `normalizeScenarioText` et application de cette normalisation lors du collage, du chargement local et de l'import JSON dans `assets/js/simple-mode.js`.  
- Remplacement du marqueur texte par une puce (`•`) dans la matrice simplifiée via `renderMatrix` et ajustement visuel du marqueur en CSS.  
- Introduction d’une échelle d’efficacité discrète `EFFECTIVENESS_LEVELS` et d’une fonction `nearestEffectivenessLevel` pour contraindre et arrondir la valeur du slider aux niveaux (0/25/50/75/100), plus adaptation du contrôle (`min`/`max`/`step`) dans `assets/js/simple-mode.js`.  
- Suppression du bloc de cartes «Risque Brut / Mesures de maîtrise» en HTML pour la version simplifiée et retrait du CSS associé.  
- Actualisation des dégradés et couleurs de la matrice principale et de la matrice simplifiée dans `assets/css/main.css` pour des teintes plus vives, et ajout de styles pour améliorer l'affichage du scénario sélectionné (`.simple-current-scenario`).  
- Fichiers modifiés : `CartoModel.html`, `assets/js/simple-mode.js`, `assets/css/main.css`.  

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check assets/js/simple-mode.js` et réussie.  
- Diff et état du dépôt revus (`git diff` / `git status`) pour valider les modifications apportées aux trois fichiers ciblés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ff8d0d78832e9bc6581e13748570)