### PR TITLE
Ajout des facteurs aggravants en version simplifiée et bump version 2.1.9

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.8</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.9</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -265,6 +265,10 @@ Cadeau inapproprié à un agent public"></textarea>
                                     <div class="matrix-description-header">Risque brut</div>
                                     <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
                                     <div class="simple-legend-sub" id="simpleRawLegendDetail">Sélectionnez une case pour afficher la cotation détaillée.</div>
+                                    <div class="simple-aggravating-factors">
+                                        <h4>Facteurs aggravants</h4>
+                                        <div id="simpleAggravatingFactors" class="simple-aggravating-list"></div>
+                                    </div>
                                     <div class="simple-legend-description">
                                         <div class="simple-legend-block">
                                             <h4 id="simpleLegendProbabilityTitle">Probabilité 1 – Peu probable</h4>
@@ -680,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.8</span>
+            <span class="app-version">Version 2.1.9</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2554,6 +2554,35 @@ tbody tr:hover {
     color: #64748b;
 }
 
+.simple-aggravating-factors {
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid #d8e0e8;
+}
+
+.simple-aggravating-factors h4 {
+    margin: 0 0 8px;
+    color: #27313d;
+    font-size: 1rem;
+}
+
+.simple-aggravating-list {
+    display: grid;
+    gap: 8px;
+}
+
+.simple-aggravating-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    color: #4b5b6a;
+    font-size: 0.95rem;
+}
+
+.simple-aggravating-item input {
+    margin-top: 2px;
+}
+
 .simple-nav-actions {
     margin-top: 16px;
     display: flex;

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,11 +1,17 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.8',
+        version: '2.1.9',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
+    const AGGRAVATING_FACTORS = [
+        { id: 'tiers_sensible', label: 'Recours à un tiers/intermédiaire sensible' },
+        { id: 'multi_pays', label: 'Contexte multi-pays à risque élevé' },
+        { id: 'pression_delai', label: 'Pression forte sur les délais/résultats' },
+        { id: 'faible_tracabilite', label: 'Traçabilité documentaire insuffisante' }
+    ];
     const MAX_SCENARIO_LENGTH = 500;
     const EFFECTIVENESS_LEVELS = [
         { value: 0, label: 'Non évaluée' },
@@ -118,6 +124,7 @@
                             prob: clampMatrixValue(s.raw?.prob),
                             impact: clampMatrixValue(s.raw?.impact)
                         },
+                        aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
                         effectiveness: nearestEffectivenessLevel(s.effectiveness),
                         comment: s.comment || ''
                     }))
@@ -148,6 +155,7 @@
             id: uid(),
             text,
             raw: { prob: 1, impact: 1 },
+            aggravatingFactors: [],
             effectiveness: EFFECTIVENESS_LEVELS[0].value,
             comment: ''
         }));
@@ -162,7 +170,9 @@
         const cloned = {
             ...current,
             id: uid(),
-            text: `${current.text} (copie)`
+            text: `${current.text} (copie)`,
+            raw: { ...current.raw },
+            aggravatingFactors: [...(current.aggravatingFactors || [])]
         };
         const index = state.data.scenarios.findIndex((s) => s.id === current.id);
         state.data.scenarios.splice(index + 1, 0, cloned);
@@ -177,6 +187,12 @@
         Object.assign(current, patch);
         saveLocal();
         renderAssessment();
+    }
+
+    function normalizeAggravatingFactors(value) {
+        if (!Array.isArray(value)) return [];
+        const allowed = new Set(AGGRAVATING_FACTORS.map((factor) => factor.id));
+        return [...new Set(value.map((item) => String(item)).filter((id) => allowed.has(id)))];
     }
 
     function goToScenario(step) {
@@ -260,6 +276,7 @@
         dom.nextBtn.disabled = disabled;
         dom.effectiveness.disabled = disabled;
         dom.comment.disabled = disabled;
+        renderAggravatingFactors(scenario);
 
         if (!scenario) {
             dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
@@ -294,6 +311,40 @@
         const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
         dom.prevBtn.disabled = idx <= 0;
         dom.nextBtn.disabled = idx >= state.data.scenarios.length - 1;
+    }
+
+    function renderAggravatingFactors(scenario) {
+        if (!dom.aggravatingFactorsList) return;
+        dom.aggravatingFactorsList.innerHTML = '';
+        const selectedFactors = new Set(scenario?.aggravatingFactors || []);
+
+        AGGRAVATING_FACTORS.forEach((factor) => {
+            const label = document.createElement('label');
+            label.className = 'simple-aggravating-item';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.value = factor.id;
+            checkbox.checked = selectedFactors.has(factor.id);
+            checkbox.disabled = !scenario;
+            checkbox.addEventListener('change', () => {
+                if (!scenario) return;
+                const factorSet = new Set(scenario.aggravatingFactors || []);
+                if (checkbox.checked) {
+                    factorSet.add(factor.id);
+                } else {
+                    factorSet.delete(factor.id);
+                }
+                updateCurrentScenario({ aggravatingFactors: [...factorSet] });
+            });
+
+            const text = document.createElement('span');
+            text.textContent = factor.label;
+
+            label.appendChild(checkbox);
+            label.appendChild(text);
+            dom.aggravatingFactorsList.appendChild(label);
+        });
     }
 
     function renderLegendDescription(probability, impact) {
@@ -353,6 +404,7 @@
                         prob: clampMatrixValue(s.raw?.prob),
                         impact: clampMatrixValue(s.raw?.impact)
                     },
+                    aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
                     effectiveness: nearestEffectivenessLevel(s.effectiveness),
                     comment: s.comment || ''
                 })).filter((s) => s.text);
@@ -417,6 +469,7 @@
         dom.legendProbabilityDetail2 = document.getElementById('simpleLegendProbabilityDetail2');
         dom.legendImpactTitle = document.getElementById('simpleLegendImpactTitle');
         dom.legendImpactBullets = document.getElementById('simpleLegendImpactBullets');
+        dom.aggravatingFactorsList = document.getElementById('simpleAggravatingFactors');
         dom.effectiveness = document.getElementById('simpleEffectiveness');
         dom.effectiveness.min = String(EFFECTIVENESS_LEVELS[0].value);
         dom.effectiveness.max = String(EFFECTIVENESS_LEVELS[EFFECTIVENESS_LEVELS.length - 1].value);


### PR DESCRIPTION
### Motivation
- Ajouter sous la légende du risque brut (version simplifiée) un bloc permettant de sélectionner des facteurs aggravants pour chaque scénario afin d'enrichir l'évaluation heuristique.
- Persister ces sélections dans les données simplifiées et dans l'import/export JSON pour garder l'état entre sessions.
- Veiller à cloner correctement les données lors de la duplication de scénario pour éviter la perte d'informations imbriquées.
- Mettre à jour le numéro de version affiché dans le footer et dans les données (`2.1.9`) conformément à la règle de versioning demandée.

### Description
- Ajout d'un bloc HTML `div.simple-aggravating-factors` avec une zone `#simpleAggravatingFactors` sous la légende du risque brut dans `CartoModel.html`.
- Ajout dans `assets/js/simple-mode.js` du support complet : constante `AGGRAVATING_FACTORS`, nouveau champ `aggravatingFactors` dans `DEFAULT_DATA`, normalisation via `normalizeAggravatingFactors()`, rendu interactif `renderAggravatingFactors()`, et sauvegarde/chargement/import/export des facteurs.
- Correction de la duplication de scénario pour cloner `raw` et `aggravatingFactors` afin d'éviter le partage de références et préserver l'état dupliqué.
- Ajout de styles CSS (`.simple-aggravating-*`) dans `assets/css/main.css` pour présenter proprement la liste de cases à cocher et mise à jour du numéro de version (`2.1.9`) dans le titre et le footer de `CartoModel.html`.

### Testing
- Exécution de la vérification syntaxique JS avec `node --check assets/js/simple-mode.js` qui a réussi.
- Aucun test automatisé additionnel disponible dans cet environnement; changements limités au mode simplifié et aux assets front-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d801401e3c832e98054c1937f383a4)