### PR TITLE
Matrice simplifiée carrée et amélioration de la puce de risque (v2.1.10)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.9</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.10</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.9</span>
+            <span class="app-version">Version 2.1.10</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2596,6 +2596,8 @@ tbody tr:hover {
 
 .simple-edit-matrix {
     width: min(500px, 100%);
+    height: auto;
+    aspect-ratio: 1 / 1;
     border: 1px solid #8ea8c5;
     background: #ffffff;
     border-radius: 10px;
@@ -2630,7 +2632,8 @@ tbody tr:hover {
     border: 2px solid #ffffff;
     box-shadow: 0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28);
     color: #ffffff;
-    font-size: 1.5rem;
+    font-size: 1.8rem;
+    font-weight: 700;
     line-height: 1;
 }
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.9',
+        version: '2.1.10',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -258,7 +258,8 @@
         marker.className = 'simple-marker risk-point brut';
         marker.draggable = true;
         marker.title = 'Glissez-déposez ce marqueur dans une autre case';
-        marker.textContent = '•';
+        marker.textContent = '●';
+        marker.setAttribute('aria-label', 'Puce de position du risque');
         marker.addEventListener('dragstart', (evt) => {
             evt.dataTransfer.setData('text/plain', 'marker');
         });


### PR DESCRIPTION
### Motivation
- Rendre la version simplifiée visuellement carrée pour éviter des déformations et améliorer l'UX sur la grille de cotation. 
- Rendre la puce représentant la position d’un risque plus visible et accessible dans la matrice simplifiée. 
- Mettre à jour le numéro de version affiché pour refléter la livraison de la modification (`2.1.10`).

### Description
- CSS: la classe `.simple-edit-matrix` reçoit `height: auto` et `aspect-ratio: 1 / 1` pour forcer une grille strictement carrée (`assets/css/main.css`).
- CSS: la puce `.simple-edit-matrix .simple-marker` a été agrandie et renforcée (`font-size: 1.8rem; font-weight: 700`) pour améliorer la lisibilité (`assets/css/main.css`).
- JS: le marqueur placé dans la grille passe du glyphe `•` à `●` et reçoit un `aria-label` (`Puce de position du risque`) pour meilleure accessibilité (`assets/js/simple-mode.js`).
- Version: le numéro a été incrémenté à `2.1.10` dans le titre/footer et dans les données par défaut de la version simplifiée (`CartoModel.html`, `assets/js/simple-mode.js`).

### Testing
- Exécution de la vérification de syntaxe JS via `node --check assets/js/simple-mode.js` — succès.
- Recherche des occurrences de version via `rg -n "2\.1\.9|2\.1\.10"` pour confirmer la mise à jour — succès et `2.1.10` présent dans le footer et les sources.
- Aucun test automatisé d’UI visuel exécuté dans cet environnement (capture/aperçu non disponible ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d802c2acd4832e91abb9f0f4865f54)