### PR TITLE
Aligner facteurs aggravants mode simplifié et incrémenter version à 2.1.11

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.10</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.11</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.10</span>
+            <span class="app-version">Version 2.1.11</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,16 +1,17 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.10',
+        version: '2.1.11',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
-    const AGGRAVATING_FACTORS = [
-        { id: 'tiers_sensible', label: 'Recours à un tiers/intermédiaire sensible' },
-        { id: 'multi_pays', label: 'Contexte multi-pays à risque élevé' },
-        { id: 'pression_delai', label: 'Pression forte sur les délais/résultats' },
-        { id: 'faible_tracabilite', label: 'Traçabilité documentaire insuffisante' }
+    const DEFAULT_AGGRAVATING_FACTORS = [
+        { id: 'Professionnels de santé', label: 'Professionnels de santé' },
+        { id: 'Institutionnels', label: 'Institutionnels' },
+        { id: 'Acheteurs', label: 'Acheteurs' },
+        { id: 'Politiques', label: 'Politiques' },
+        { id: 'Collaborateurs', label: 'Collaborateurs' }
     ];
     const MAX_SCENARIO_LENGTH = 500;
     const EFFECTIVENESS_LEVELS = [
@@ -90,6 +91,29 @@
         return EFFECTIVENESS_LEVELS.reduce((closest, level) => (
             Math.abs(level.value - numeric) < Math.abs(closest.value - numeric) ? level : closest
         ), EFFECTIVENESS_LEVELS[0]).value;
+    }
+
+    function getAggravatingFactors() {
+        const configuredTiers = Array.isArray(window.rms?.config?.tiers)
+            ? window.rms.config.tiers
+            : [];
+
+        const factors = configuredTiers
+            .map((tier) => {
+                if (tier && typeof tier === 'object') {
+                    const id = String(tier.value || tier.label || '').trim();
+                    const label = String(tier.label || tier.value || '').trim();
+                    if (!id || !label) return null;
+                    return { id, label };
+                }
+
+                const value = String(tier || '').trim();
+                if (!value) return null;
+                return { id: value, label: value };
+            })
+            .filter(Boolean);
+
+        return factors.length ? factors : DEFAULT_AGGRAVATING_FACTORS;
     }
 
     function scoreToLevel(score) {
@@ -191,7 +215,7 @@
 
     function normalizeAggravatingFactors(value) {
         if (!Array.isArray(value)) return [];
-        const allowed = new Set(AGGRAVATING_FACTORS.map((factor) => factor.id));
+        const allowed = new Set(getAggravatingFactors().map((factor) => factor.id));
         return [...new Set(value.map((item) => String(item)).filter((id) => allowed.has(id)))];
     }
 
@@ -319,7 +343,7 @@
         dom.aggravatingFactorsList.innerHTML = '';
         const selectedFactors = new Set(scenario?.aggravatingFactors || []);
 
-        AGGRAVATING_FACTORS.forEach((factor) => {
+        getAggravatingFactors().forEach((factor) => {
             const label = document.createElement('label');
             label.className = 'simple-aggravating-item';
 


### PR DESCRIPTION
### Motivation
- Garantir que la liste des facteurs aggravants utilisée par la "version simplifiée" soit la même que celle du reste de la webapp afin d’éviter des incohérences métier entre modes.
- Fournir un fallback lisible lorsque la configuration centrale n’est pas encore disponible pour que le mode simplifié reste utilisable.
- Respecter la consigne de mise à jour de la version visible après modification fonctionnelle en incrémentant la version du footer et des exports.

### Description
- Remplace la liste statique des facteurs aggravants par une source unique dérivée de la configuration `window.rms.config.tiers` via la nouvelle fonction `getAggravatingFactors()` avec normalisation objet/chaîne et fallback `DEFAULT_AGGRAVATING_FACTORS`.
- Fait en sorte que la validation/import des facteurs (`normalizeAggravatingFactors`) utilise la même source dynamique pour rejeter les valeurs hors configuration active.
- Met à jour l’affichage des facteurs (`renderAggravatingFactors`) pour itérer sur `getAggravatingFactors()` au lieu de la liste statique.
- Incrémente la version de la webapp de `2.1.10` à `2.1.11` dans `assets/js/simple-mode.js` (`DEFAULT_DATA.version`) et dans `CartoModel.html` (titre et footer).
- Fichiers modifiés : `assets/js/simple-mode.js`, `CartoModel.html`.

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check assets/js/simple-mode.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d803b1d56c832e81b59eca4c85d4ad)