### PR TITLE
Fix simple mode: marker visibility, square 4x4 matrix, sync aggravating factors, bump version to 2.1.12

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.11</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.12</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.11</span>
+            <span class="app-version">Version 2.1.12</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2519,6 +2519,8 @@ tbody tr:hover {
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(4, 1fr);
     gap: 0;
+    width: 100%;
+    height: 100%;
 }
 
 .simple-matrix-cell {
@@ -2596,6 +2598,7 @@ tbody tr:hover {
 
 .simple-edit-matrix {
     width: min(500px, 100%);
+    max-width: 100%;
     height: auto;
     aspect-ratio: 1 / 1;
     border: 1px solid #8ea8c5;
@@ -2629,12 +2632,22 @@ tbody tr:hover {
 }
 
 .simple-edit-matrix .simple-marker {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border: 2px solid #ffffff;
     box-shadow: 0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28);
-    color: #ffffff;
-    font-size: 1.8rem;
-    font-weight: 700;
-    line-height: 1;
+    color: transparent;
+    font-size: 0;
+    line-height: 0;
+}
+
+.simple-edit-matrix .simple-marker span {
+    width: 11px;
+    height: 11px;
+    border-radius: 50%;
+    background: #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
 }
 
 .simple-edit-matrix .axis-label {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.11',
+        version: '2.1.12',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -94,11 +94,20 @@
     }
 
     function getAggravatingFactors() {
+        const configuredFactors = Array.isArray(window.rms?.config?.aggravatingFactors)
+            ? window.rms.config.aggravatingFactors
+            : [];
         const configuredTiers = Array.isArray(window.rms?.config?.tiers)
             ? window.rms.config.tiers
             : [];
+        const formTiers = Array.from(document.querySelectorAll('#tiers option'))
+            .map((option) => ({
+                id: String(option.value || '').trim(),
+                label: String(option.textContent || option.value || '').trim()
+            }))
+            .filter((factor) => factor.id && factor.label);
 
-        const factors = configuredTiers
+        const factors = [...configuredFactors, ...configuredTiers, ...formTiers]
             .map((tier) => {
                 if (tier && typeof tier === 'object') {
                     const id = String(tier.value || tier.label || '').trim();
@@ -113,7 +122,11 @@
             })
             .filter(Boolean);
 
-        return factors.length ? factors : DEFAULT_AGGRAVATING_FACTORS;
+        const uniqueFactors = Array.from(
+            new Map(factors.map((factor) => [factor.id, factor])).values()
+        );
+
+        return uniqueFactors.length ? uniqueFactors : DEFAULT_AGGRAVATING_FACTORS;
     }
 
     function scoreToLevel(score) {
@@ -282,13 +295,16 @@
         marker.className = 'simple-marker risk-point brut';
         marker.draggable = true;
         marker.title = 'Glissez-déposez ce marqueur dans une autre case';
-        marker.textContent = '●';
+        marker.innerHTML = '<span aria-hidden="true"></span>';
         marker.setAttribute('aria-label', 'Puce de position du risque');
         marker.addEventListener('dragstart', (evt) => {
             evt.dataTransfer.setData('text/plain', 'marker');
         });
 
-        dom.matrix.appendChild(marker);
+        const firstCell = dom.matrix.querySelector('.simple-matrix-cell');
+        if (firstCell) {
+            firstCell.appendChild(marker);
+        }
     }
 
     function renderAssessment() {


### PR DESCRIPTION
### Motivation
- Corriger la puce de position dans la "version simplifiée" qui n’était pas visible et s’installait en dehors de la grille, provoquant un élément en trop et une matrice déformée.  
- S’assurer que la matrice simplifiée reste bien carrée (4×4) quel que soit le conteneur.  
- Harmoniser les facteurs aggravants affichés en version simplifiée avec ceux utilisés par le reste de l’application.  
- Mettre à jour la version affichée dans le footer et l’export simplifié comme demandé (nouvelle version : `2.1.12`).

### Description
- Bumped default simple-mode data version from `2.1.11` to `2.1.12` in `assets/js/simple-mode.js` and updated page title/footer in `CartoModel.html`.  
- Reworked `getAggravatingFactors()` in `assets/js/simple-mode.js` to source factors from `config.aggravatingFactors`, `config.tiers` and the `#tiers` form options, then de-duplicate entries before returning (falls back to `DEFAULT_AGGRAVATING_FACTORS` if empty).  
- Fixed marker rendering in `renderMatrix()` so the marker element is appended into the first matrix cell (never added as a separate 17th grid child), and changed marker content to an inner `<span>` to produce a visible dot.  
- CSS adjustments in `assets/css/main.css` to enforce square behaviour for the simplified grid (`.simple-matrix` width/height and `.simple-edit-matrix` constraints) and to style the marker inner dot for better contrast and consistent centering.

### Testing
- Ran `node --check assets/js/simple-mode.js` and it completed without syntax errors.  
- No automated UI screenshot/visual tests available in this environment, manual verification recommended in a browser after deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d804eeb05c832e8b344778b9d1e0aa)