### PR TITLE
Mettre à jour facteurs aggravants et échelle d'efficacité (v2.1.13)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.12</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.13</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -285,7 +285,7 @@ Cadeau inapproprié à un agent public"></textarea>
                             <div class="simple-effectiveness-block">
                                 <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
                                 <input type="range" id="simpleEffectiveness" min="0" max="100" step="5" value="0">
-                                <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Non évaluée</div>
+                                <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Inefficace</div>
                             </div>
                         </div>
 
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.12</span>
+            <span class="app-version">Version 2.1.13</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,25 +1,26 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.12',
+        version: '2.1.13',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
     const DEFAULT_AGGRAVATING_FACTORS = [
-        { id: 'Professionnels de santé', label: 'Professionnels de santé' },
-        { id: 'Institutionnels', label: 'Institutionnels' },
-        { id: 'Acheteurs', label: 'Acheteurs' },
-        { id: 'Politiques', label: 'Politiques' },
-        { id: 'Collaborateurs', label: 'Collaborateurs' }
+        { id: 'Pays à risque de corruption élevé (CPI < 40)', label: 'Pays à risque de corruption élevé (CPI < 40)' },
+        { id: 'Zones géographiques instables', label: 'Zones géographiques instables' },
+        { id: 'Intermédiaires difficiles à contrôler', label: 'Intermédiaires difficiles à contrôler' },
+        { id: 'Pays à risque de corruption modéré (40 ≤ CPI < 60)', label: 'Pays à risque de corruption modéré (40 ≤ CPI < 60)' },
+        { id: 'Secteurs d’activité exposés (BTP, énergie, défense)', label: 'Secteurs d’activité exposés (BTP, énergie, défense)' },
+        { id: 'Culture tolérante aux cadeaux', label: 'Culture tolérante aux cadeaux' },
+        { id: 'Turn-over élevé', label: 'Turn-over élevé' }
     ];
     const MAX_SCENARIO_LENGTH = 500;
     const EFFECTIVENESS_LEVELS = [
-        { value: 0, label: 'Non évaluée' },
-        { value: 25, label: 'Faible' },
-        { value: 50, label: 'Partielle' },
-        { value: 75, label: 'Efficace' },
-        { value: 100, label: 'Très efficace' }
+        { value: 0, label: 'Inefficace' },
+        { value: 25, label: 'Insuffisant' },
+        { value: 50, label: 'Améliorable' },
+        { value: 75, label: 'Efficace' }
     ];
     const PROBABILITY_LEGEND = {
         1: {
@@ -250,7 +251,7 @@
     }
 
     function effectivenessLabel(value) {
-        return EFFECTIVENESS_LEVELS.find((level) => level.value === nearestEffectivenessLevel(value))?.label || 'Non évaluée';
+        return EFFECTIVENESS_LEVELS.find((level) => level.value === nearestEffectivenessLevel(value))?.label || 'Inefficace';
     }
 
     function renderScenarioList() {
@@ -324,7 +325,7 @@
             dom.rawLegendDetail.textContent = 'Chargez des scénarios pour commencer la cotation.';
             renderLegendDescription(1, 1);
             dom.effectiveness.value = 0;
-            dom.effectivenessLegend.textContent = '0% - Non évaluée';
+            dom.effectivenessLegend.textContent = '0% - Inefficace';
             dom.comment.value = '';
             return;
         }


### PR DESCRIPTION
### Motivation
- Adapter la version simplifiée pour utiliser la liste de facteurs aggravants fournie et une échelle d’efficacité alignée sur la grille demandée. 
- Harmoniser les libellés affichés dans l’interface pour l’état initial d’efficacité. 
- Respecter la consigne de versionning en incrémentant le numéro affiché en footer et métadonnées à `2.1.13`.

### Description
- Remplacement de la liste par défaut `DEFAULT_AGGRAVATING_FACTORS` dans `assets/js/simple-mode.js` par les 7 facteurs fournis (CPI, zones instables, intermédiaires, secteurs exposés, culture cadeaux, turn-over, etc.).
- Remplacement de `EFFECTIVENESS_LEVELS` dans `assets/js/simple-mode.js` par 4 niveaux : `0% - Inefficace`, `25% - Insuffisant`, `50% - Améliorable`, `75% - Efficace` (suppression du palier `100%`).
- Ajustement des libellés et fallback : `effectivenessLabel` now returns `Inefficace` par défaut et l’affichage initial passe à `0% - Inefficace` dans `assets/js/simple-mode.js` et `CartoModel.html`.
- Incrémentation de la version applicative/données à `2.1.13` dans `assets/js/simple-mode.js`, le `<title>` et le footer (`CartoModel.html`).

### Testing
- Exécution de `node --check assets/js/simple-mode.js` pour valider la syntaxe JavaScript, test réussi. 
- Exécution de `git diff --check` pour repérer les problèmes d’espace/syntaxe dans les diffs, test réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d806be7924832eb7e2ac63b3b2891c)