### PR TITLE
Mise à jour des facteurs aggravants (version simplifiée) et bump vers 2.1.15

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.14</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.15</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.14</span>
+            <span class="app-version">Version 2.1.15</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,16 +1,16 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.14',
+        version: '2.1.15',
         scenarios: [],
         selectedId: null,
         updatedAt: null
     };
     const DEFAULT_AGGRAVATING_FACTORS = [
         { id: 'Pays à risque de corruption élevé (CPI < 40)', label: 'Pays à risque de corruption élevé (CPI < 40)' },
-        { id: 'Zones géographiques instables', label: 'Zones géographiques instables' },
-        { id: 'Intermédiaires difficiles à contrôler', label: 'Intermédiaires difficiles à contrôler' },
         { id: 'Pays à risque de corruption modéré (40 ≤ CPI < 60)', label: 'Pays à risque de corruption modéré (40 ≤ CPI < 60)' },
+        { id: 'Intermédiaires difficiles à contrôler', label: 'Intermédiaires difficiles à contrôler' },
+        { id: 'Zones géographiques instables', label: 'Zones géographiques instables' },
         { id: 'Secteurs d’activité exposés (BTP, énergie, défense)', label: 'Secteurs d’activité exposés (BTP, énergie, défense)' },
         { id: 'Culture tolérante aux cadeaux', label: 'Culture tolérante aux cadeaux' },
         { id: 'Turn-over élevé', label: 'Turn-over élevé' }


### PR DESCRIPTION
### Motivation
- Aligner l’ordre des facteurs aggravants de la "Version simplifiée" sur la liste demandée pour améliorer l’expérience utilisateur et la cohérence des scénarios. 
- Incrémenter le numéro de version applicative afin de marquer la modification et respecter la règle de mise à jour du footer à chaque tâche.

### Description
- Réordonnance le tableau `DEFAULT_AGGRAVATING_FACTORS` dans `assets/js/simple-mode.js` pour refléter la séquence demandée (CPI < 40, 40 ≤ CPI < 60, Intermédiaires..., Zones instables, Secteurs exposés, Culture cadeaux, Turn-over). 
- Bump de la valeur `version` de `DEFAULT_DATA` dans `assets/js/simple-mode.js` à `2.1.15`.
- Mise à jour du titre HTML et du footer dans `CartoModel.html` pour afficher `v2.1.15` et `Version 2.1.15` conformément à l'exigence de mise à jour du footer.

### Testing
- Recherche texte exécutée avec `rg` pour vérifier la présence des nouveaux facteurs et du tag `2.1.15`, et la vérification a réussi. 
- Différences inspectées via `git diff` et l’état du dépôt contrôlé avec `git status`, et ces vérifications ont réussi. 
- Les changements ont été commités avec `git commit` et la création de la PR a été effectuée automatiquement, et l’opération a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d809d9c000832e8d733e16df0df08e)