### PR TITLE
Mode simplifié : facteurs aggravants en 2 colonnes (v2.1.17)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.16</span>
+            <span class="app-version">Version 2.1.17</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2572,7 +2572,8 @@ tbody tr:hover {
 
 .simple-aggravating-list {
     display: grid;
-    gap: 8px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 14px;
 }
 
 .simple-aggravating-item {
@@ -2713,6 +2714,10 @@ tbody tr:hover {
 
 @media (max-width: 980px) {
     .simple-matrix-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .simple-aggravating-list {
         grid-template-columns: 1fr;
     }
 }

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.16',
+        version: '2.1.17',
         scenarios: [],
         selectedId: null,
         updatedAt: null


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité de la liste des facteurs aggravants en version simplifiée en les affichant sur deux colonnes et mettre à jour la version produit à `2.1.17`.

### Description
- Ajustements CSS et versioning : `assets/css/main.css` rend `.simple-aggravating-list` en grille à deux colonnes avec espacement horizontal, ajoute une media query pour repasser à une colonne sur écrans ≤ 980px, et la version a été incrémentée à `2.1.17` dans `CartoModel.html` et `assets/js/simple-mode.js`.

### Testing
- Tests automatisés exécutés : `git diff --check` et commit (`git commit`) se sont déroulés sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80d1b5a88832eac1dd041b787208e)