### PR TITLE
Bump app version to 2.1.19 and trigger assessment render on view switch

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.18</span>
+            <span class="app-version">Version 2.1.19</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.18',
+        version: '2.1.19',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -428,6 +428,12 @@
         });
         dom.scenariosPanel.classList.toggle('active', viewName === 'scenarios');
         dom.assessmentPanel.classList.toggle('active', viewName === 'assessment');
+
+        if (viewName === 'assessment') {
+            requestAnimationFrame(() => {
+                renderAssessment();
+            });
+        }
     }
 
     function exportData() {


### PR DESCRIPTION
### Motivation
- Bump the app version to `2.1.19` and ensure the simplified-mode assessment panel is rendered when the view is activated so the UI stays up-to-date.

### Description
- Updated the version string in `CartoModel.html` footer and `DEFAULT_DATA.version` in `assets/js/simple-mode.js` to `2.1.19`.
- Added a `requestAnimationFrame` call inside `setView` to invoke `renderAssessment()` when `viewName === 'assessment'`, forcing a re-render of the assessment panel on activation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d810c1d744832e89a5f905c9c59ed6)