### PR TITLE
Bump version to 2.1.20 and initialize assessment view in simple mode

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.18</span>
+            <span class="app-version">Version 2.1.20</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.18',
+        version: '2.1.20',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -428,6 +428,19 @@
         });
         dom.scenariosPanel.classList.toggle('active', viewName === 'scenarios');
         dom.assessmentPanel.classList.toggle('active', viewName === 'assessment');
+
+        if (viewName === 'assessment') {
+            if (!state.data.selectedId && state.data.scenarios.length) {
+                state.data.selectedId = state.data.scenarios[0].id;
+            }
+            renderAssessment();
+            const scenario = getSelectedScenario();
+            if (scenario) {
+                requestAnimationFrame(() => {
+                    positionSimpleMarker(scenario.raw.prob, scenario.raw.impact);
+                });
+            }
+        }
     }
 
     function exportData() {


### PR DESCRIPTION
### Motivation

- Update the app version metadata and ensure the simple-mode assessment view properly initializes and displays a selected scenario when opened.

### Description

- Updated the displayed app version in `CartoModel.html` from `2.1.18` to `2.1.20`.
- Updated the `DEFAULT_DATA.version` value in `assets/js/simple-mode.js` to `2.1.20`.
- Enhanced `setView` in `assets/js/simple-mode.js` to automatically select the first scenario when switching to the `assessment` view if no scenario is selected, call `renderAssessment()`, and position the simple-mode marker via `positionSimpleMarker` inside a `requestAnimationFrame` callback.

### Testing

- Ran `npm run lint` to verify code style and static checks, which completed successfully.
- Ran unit tests with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d810c1d744832e89a5f905c9c59ed6)