### PR TITLE
Répare la sélection en mode simplifié et empêche le marqueur de bloquer les clics (v2.1.20)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.18</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.20</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.19</span>
+            <span class="app-version">Version 2.1.20</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2659,6 +2659,7 @@ tbody tr:hover {
     transform: translate(-50%, -50%);
     transition: left 220ms ease, top 220ms ease, box-shadow 220ms ease;
     z-index: 5;
+    pointer-events: none;
 }
 
 .simple-edit-matrix .axis-label {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.19',
+        version: '2.1.20',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -166,6 +166,20 @@
 
     function getSelectedScenario() {
         return state.data.scenarios.find((s) => s.id === state.data.selectedId) || null;
+    }
+
+    function ensureSelectedScenario() {
+        if (!state.data.scenarios.length) {
+            state.data.selectedId = null;
+            return null;
+        }
+
+        const hasSelectedScenario = state.data.scenarios.some((scenario) => scenario.id === state.data.selectedId);
+        if (!hasSelectedScenario) {
+            state.data.selectedId = state.data.scenarios[0].id;
+        }
+
+        return state.data.selectedId;
     }
 
     function selectScenario(id) {
@@ -525,6 +539,7 @@
     }
 
     function render() {
+        ensureSelectedScenario();
         renderScenarioList();
         renderAssessment();
     }
@@ -563,10 +578,7 @@
         }
 
         loadLocal();
-
-        if (!state.data.selectedId && state.data.scenarios.length) {
-            state.data.selectedId = state.data.scenarios[0].id;
-        }
+        ensureSelectedScenario();
 
         renderMatrix();
         bindEvents();


### PR DESCRIPTION
### Motivation
- En version simplifiée le marqueur (chip) pouvait être invisible et les clics sur les cases ne produisaient plus d’effet, et les facteurs aggravants n’étaient plus sélectionnables quand `selectedId` était invalide.
- Il faut garantir qu’un scénario valide soit toujours sélectionné avant d’afficher la vue d’évaluation pour restaurer les interactions (clics sur cases, drag/drop et checkboxes).
- Le marqueur bloquait les clics sur les cellules sous-jacentes, il doit donc devenir non-interactif.

### Description
- Ajout de la fonction `ensureSelectedScenario()` qui replace automatiquement `state.data.selectedId` par le premier scénario si l’ID est manquant ou obsolète, et appel de cette fonction depuis `render()` et `init()` pour sécuriser l’affichage; modification dans `assets/js/simple-mode.js`.
- Modification CSS pour `.simple-edit-matrix .simple-marker` afin d’ajouter `pointer-events: none;` pour éviter que le marqueur n’intercepte les clics sur la matrice; changement dans `assets/css/main.css`.
- Mise à jour des références de version à `2.1.20` dans `assets/js/simple-mode.js` (DEFAULT_DATA.version), `CartoModel.html` (titre et footer) conformément à la consigne de versioning.

### Testing
- Exécution d’un contrôle de syntaxe JavaScript avec `node -e "const fs=require('fs'); new Function(fs.readFileSync('assets/js/simple-mode.js','utf8')); console.log('simple-mode.js: syntax OK')"` qui a réussi.
- Aucun autre test automatisé (unitaires/intégration) n’a été exécuté dans cet environnement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8149ee660832eba452748cfb94be5)