### PR TITLE
Affiche la puce sur la case sélectionnée en mode simplifié

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.20</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.21</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.20</span>
+            <span class="app-version">Version 2.1.21</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2529,15 +2529,6 @@ tbody tr:hover {
     min-height: unset;
 }
 
-.simple-marker {
-    position: static;
-    font-size: 0.9rem;
-    width: 30px;
-    height: 30px;
-    cursor: grab;
-    margin: auto;
-}
-
 .simple-legend-card,
 .simple-slider-card,
 .simple-comment-card {
@@ -2622,6 +2613,9 @@ tbody tr:hover {
     border: 3px solid #0a3f74;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.9);
     z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .simple-edit-matrix .simple-matrix-cell.level-1 {
@@ -2640,24 +2634,22 @@ tbody tr:hover {
     background: linear-gradient(135deg, #ff8aa6, #ff355f);
 }
 
-.simple-edit-matrix .simple-marker {
-    position: absolute;
-    margin: 0;
+.simple-edit-matrix .simple-cell-marker {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 34px;
     height: 34px;
+    border-radius: 50%;
     border: 2px solid #ffffff;
     box-shadow: 0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28);
+    background: linear-gradient(135deg, #4b91c5, #0061af);
     color: #ffffff;
     font-size: 1.05rem;
     font-weight: 700;
     line-height: 1;
     letter-spacing: 0;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.28);
-    transform: translate(-50%, -50%);
-    transition: left 220ms ease, top 220ms ease, box-shadow 220ms ease;
     z-index: 5;
     pointer-events: none;
 }

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.20',
+        version: '2.1.21',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -65,7 +65,6 @@
     };
 
     const dom = {};
-    let simpleMarkerInitialized = false;
 
     function cloneData(data) {
         if (typeof structuredClone === 'function') {
@@ -296,44 +295,6 @@
             }
         }
 
-        const marker = document.createElement('div');
-        marker.id = 'simpleMatrixMarker';
-        marker.className = 'simple-marker risk-point brut';
-        marker.draggable = true;
-        marker.title = 'Glissez-déposez ce marqueur dans une autre case';
-        marker.textContent = 'B';
-        marker.setAttribute('aria-label', 'Puce de position du risque');
-        marker.addEventListener('dragstart', (evt) => {
-            evt.dataTransfer.setData('text/plain', 'marker');
-        });
-
-        dom.matrix.appendChild(marker);
-        simpleMarkerInitialized = false;
-    }
-
-    function positionSimpleMarker(prob, impact) {
-        const marker = document.getElementById('simpleMatrixMarker');
-        if (!marker || !dom.matrix) return;
-        const matrixRect = dom.matrix.getBoundingClientRect();
-        if (!matrixRect.width || !matrixRect.height) return;
-
-        const cellWidth = matrixRect.width / 4;
-        const cellHeight = matrixRect.height / 4;
-        const left = (prob - 0.5) * cellWidth;
-        const top = (4 - impact + 0.5) * cellHeight;
-
-        marker.style.transition = simpleMarkerInitialized
-            ? ''
-            : 'none';
-        marker.style.left = `${left}px`;
-        marker.style.top = `${top}px`;
-
-        if (!simpleMarkerInitialized) {
-            requestAnimationFrame(() => {
-                marker.style.transition = '';
-            });
-            simpleMarkerInitialized = true;
-        }
     }
 
     function renderAssessment() {
@@ -366,8 +327,16 @@
         dom.matrix.querySelectorAll('.simple-matrix-cell').forEach((cell) => {
             const isActive = Number(cell.dataset.prob) === prob && Number(cell.dataset.impact) === impact;
             cell.classList.toggle('active-cell', isActive);
+            cell.innerHTML = '';
+
+            if (isActive) {
+                const marker = document.createElement('span');
+                marker.className = 'simple-cell-marker';
+                marker.textContent = 'B';
+                marker.setAttribute('aria-label', 'Puce de position du risque');
+                cell.appendChild(marker);
+            }
         });
-        positionSimpleMarker(prob, impact);
 
         const snappedEffectiveness = nearestEffectivenessLevel(scenario.effectiveness);
         if (snappedEffectiveness !== scenario.effectiveness) {
@@ -523,17 +492,13 @@
         });
 
         window.addEventListener('resize', () => {
-            const scenario = getSelectedScenario();
-            if (!scenario) return;
-            positionSimpleMarker(scenario.raw.prob, scenario.raw.impact);
+            renderAssessment();
         });
 
         document.addEventListener('rms:tab-changed', (event) => {
             if (event?.detail?.tabName !== 'simple') return;
             requestAnimationFrame(() => {
-                const scenario = getSelectedScenario();
-                if (!scenario) return;
-                positionSimpleMarker(scenario.raw.prob, scenario.raw.impact);
+                renderAssessment();
             });
         });
     }


### PR DESCRIPTION
### Motivation
- Rendre le marquage du risque dans la version simplifiée identique à la capture fournie en affichant une puce centrée dans la case active plutôt qu'un marqueur absolu flottant.  
- Simplifier la logique d'affichage pour éviter les calculs de position absolue et améliorer la robustesse au redimensionnement et au changement d'onglet.  
- Harmoniser l'apparence et indiquer la nouvelle version de l'interface sous la forme demandée dans le footer.  

### Description
- Remplace le marqueur global absolu par un marqueur par cellule en injectant un élément `span` avec la classe `simple-cell-marker` au centre de la cellule active dans `renderAssessment()` (fichier `assets/js/simple-mode.js`).  
- Supprime la logique de positionnement absolu du marqueur (`simpleMatrixMarker`, `positionSimpleMarker` et `simpleMarkerInitialized`) et remplace les handlers de redimensionnement / changement d'onglet pour ré-appeler `renderAssessment()` (fichier `assets/js/simple-mode.js`).  
- Ajoute le style centré pour la cellule active et le style visuel de la puce (cercle bleu, halo, bordure blanche, texte "B") via `assets/css/main.css`, et retire l'ancien style du marqueur global.  
- Met à jour le numéro de version à `2.1.21` dans la page et dans les données par défaut (`CartoModel.html` title + footer et `DEFAULT_DATA.version` dans `assets/js/simple-mode.js`).  

### Testing
- Exécution de `node --check assets/js/simple-mode.js` qui a terminé sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d815f38654832eb3259e4d6a8735a3)