### PR TITLE
Bump version to 2.1.22, add cache-busting and harden simple-mode data handling

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.21</title>
-    <link rel="stylesheet" href="assets/css/main.css">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.22</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.22">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -684,7 +684,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.21</span>
+            <span class="app-version">Version 2.1.22</span>
         </footer>
     </div>
 
@@ -1081,13 +1081,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js"></script>
-    <script defer src="assets/js/rms.constants.js"></script>
-    <script defer src="assets/js/rms.matrix.js"></script>
-    <script defer src="assets/js/rms.ui.js"></script>
-    <script defer src="assets/js/rms.core.js"></script>
-    <script defer src="assets/js/rms.integrations.js"></script>
-    <script defer src="assets/js/main.js"></script>
-    <script defer src="assets/js/simple-mode.js"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.22"></script>
+    <script defer src="assets/js/main.js?v=2.1.22"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.22"></script>
 </body>
 </html>

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.21',
+        version: '2.1.22',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -87,6 +87,17 @@
         return String(value || '').trim().slice(0, MAX_SCENARIO_LENGTH);
     }
 
+    function isValidSimpleScenario(candidate) {
+        if (!candidate || typeof candidate !== 'object') return false;
+        const text = normalizeScenarioText(candidate.text);
+        return Boolean(text);
+    }
+
+    function resetSimpleModeData() {
+        state.data = cloneData(DEFAULT_DATA);
+        localStorage.removeItem(STORAGE_KEY);
+    }
+
     function nearestEffectivenessLevel(value) {
         const numeric = Math.min(100, Math.max(0, Number(value) || 0));
         return EFFECTIVENESS_LEVELS.reduce((closest, level) => (
@@ -139,27 +150,41 @@
     function loadLocal() {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) return;
+
         try {
             const parsed = JSON.parse(raw);
-            if (parsed && Array.isArray(parsed.scenarios)) {
-                state.data = {
-                    ...cloneData(DEFAULT_DATA),
-                    ...parsed,
-                    scenarios: parsed.scenarios.map((s) => ({
-                        id: s.id || uid(),
-                        text: normalizeScenarioText(s.text),
-                        raw: {
-                            prob: clampMatrixValue(s.raw?.prob),
-                            impact: clampMatrixValue(s.raw?.impact)
-                        },
-                        aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
-                        effectiveness: nearestEffectivenessLevel(s.effectiveness),
-                        comment: s.comment || ''
-                    }))
-                };
+            if (!parsed || !Array.isArray(parsed.scenarios)) {
+                throw new Error('Structure invalide');
+            }
+
+            const normalizedScenarios = parsed.scenarios
+                .filter(isValidSimpleScenario)
+                .map((s) => ({
+                    id: s.id || uid(),
+                    text: normalizeScenarioText(s.text),
+                    raw: {
+                        prob: clampMatrixValue(s.raw?.prob),
+                        impact: clampMatrixValue(s.raw?.impact)
+                    },
+                    aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
+                    effectiveness: nearestEffectivenessLevel(s.effectiveness),
+                    comment: s.comment || ''
+                }));
+
+            state.data = {
+                ...cloneData(DEFAULT_DATA),
+                ...parsed,
+                version: DEFAULT_DATA.version,
+                scenarios: normalizedScenarios
+            };
+
+            const hasSelectedScenario = state.data.scenarios.some((s) => s.id === state.data.selectedId);
+            if (!hasSelectedScenario) {
+                state.data.selectedId = state.data.scenarios[0]?.id || null;
             }
         } catch (err) {
             console.warn('Impossible de charger la version simplifiée', err);
+            resetSimpleModeData();
         }
     }
 
@@ -297,6 +322,24 @@
 
     }
 
+    function styleSimpleMarkerFallback(marker) {
+        marker.style.display = 'flex';
+        marker.style.alignItems = 'center';
+        marker.style.justifyContent = 'center';
+        marker.style.width = '34px';
+        marker.style.height = '34px';
+        marker.style.borderRadius = '50%';
+        marker.style.border = '2px solid #ffffff';
+        marker.style.boxShadow = '0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28)';
+        marker.style.background = 'linear-gradient(135deg, #4b91c5, #0061af)';
+        marker.style.color = '#ffffff';
+        marker.style.fontSize = '1.05rem';
+        marker.style.fontWeight = '700';
+        marker.style.lineHeight = '1';
+        marker.style.pointerEvents = 'none';
+        marker.style.zIndex = '5';
+    }
+
     function renderAssessment() {
         const scenario = getSelectedScenario();
         const disabled = !scenario;
@@ -334,6 +377,7 @@
                 marker.className = 'simple-cell-marker';
                 marker.textContent = 'B';
                 marker.setAttribute('aria-label', 'Puce de position du risque');
+                styleSimpleMarkerFallback(marker);
                 cell.appendChild(marker);
             }
         });


### PR DESCRIPTION
### Motivation
- Update the application to version `2.1.22` and ensure clients load the latest assets reliably. 
- Make the simple-mode local storage loader more robust to malformed or older data structures. 
- Normalize and validate stored scenarios to avoid runtime errors and ensure a sane selected scenario. 
- Provide a visual fallback for the simple-mode matrix marker to improve UX when CSS/SVG markers are missing.

### Description
- Updated `CartoModel.html` to display `Sapin 2 v2.1.22` and changed the footer `app-version` to `Version 2.1.22`.
- Added cache-busting query strings to static asset links in `CartoModel.html` by appending `?v=2.1.22` to the CSS and JS includes. 
- Bumped `DEFAULT_DATA.version` in `assets/js/simple-mode.js` to `2.1.22`.
- Added `isValidSimpleScenario()` to validate scenario objects and `resetSimpleModeData()` to clear invalid state. 
- Rewrote `loadLocal()` to strictly validate the parsed structure, filter and normalize scenarios, reset `version` to the new default, and ensure `selectedId` points to an existing scenario or is cleared. 
- Introduced `styleSimpleMarkerFallback()` and applied it when rendering the active matrix marker to guarantee a consistent visible marker.
- Miscellaneous: improved data cloning, normalization and clamping logic usage when constructing normalized scenario objects.

### Testing
- Ran the linter with `npm run lint` and it completed successfully. 
- Executed the test suite with `npm test` and all tests passed. 
- Performed an automated build with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d817befe74832eace41a9b7a8cb0c4)