### PR TITLE
Simple mode: add CSV export, fix responsive matrix sizing, bump version to 2.1.23

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.22</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.22">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.23</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.23">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -216,6 +216,7 @@
                     <div class="toolbar-title">Version simplifiée - Cotation des risques bruts</div>
                     <div class="toolbar-actions">
                         <button class="btn btn-outline" id="simpleExportBtn">📤 Export JSON</button>
+                        <button class="btn btn-outline" id="simpleExportCsvBtn">📄 Export CSV</button>
                         <button class="btn btn-secondary" id="simpleImportBtn">📥 Import JSON</button>
                         <input type="file" id="simpleImportFile" accept="application/json" hidden>
                     </div>
@@ -684,7 +685,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.22</span>
+            <span class="app-version">Version 2.1.23</span>
         </footer>
     </div>
 
@@ -1081,13 +1082,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js?v=2.1.22"></script>
-    <script defer src="assets/js/rms.constants.js?v=2.1.22"></script>
-    <script defer src="assets/js/rms.matrix.js?v=2.1.22"></script>
-    <script defer src="assets/js/rms.ui.js?v=2.1.22"></script>
-    <script defer src="assets/js/rms.core.js?v=2.1.22"></script>
-    <script defer src="assets/js/rms.integrations.js?v=2.1.22"></script>
-    <script defer src="assets/js/main.js?v=2.1.22"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.22"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.23"></script>
+    <script defer src="assets/js/main.js?v=2.1.23"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.23"></script>
 </body>
 </html>

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.22',
+        version: '2.1.23',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -448,6 +448,13 @@
         }
     }
 
+    function syncSimpleMatrixSquare() {
+        if (!dom.matrixWrapper) return;
+        const width = dom.matrixWrapper.getBoundingClientRect().width;
+        if (!Number.isFinite(width) || width <= 0) return;
+        dom.matrixWrapper.style.height = `${Math.round(width)}px`;
+    }
+
     function setView(viewName) {
         state.view = viewName;
         document.querySelectorAll('.simple-subtab').forEach((btn) => {
@@ -458,6 +465,7 @@
 
         if (viewName === 'assessment') {
             requestAnimationFrame(() => {
+                syncSimpleMatrixSquare();
                 renderAssessment();
             });
         }
@@ -470,6 +478,51 @@
         const a = document.createElement('a');
         a.href = url;
         a.download = `cartographie-simplifiee-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function csvEscape(value) {
+        const stringValue = String(value ?? '');
+        const escaped = stringValue.replace(/"/g, '""');
+        if (/[",\n]/.test(escaped)) {
+            return `"${escaped}"`;
+        }
+        return escaped;
+    }
+
+    function exportCsvData() {
+        const header = [
+            'Risque',
+            'Probabilité',
+            'Impact',
+            'Facteurs aggravants',
+            'Efficacité des mesures',
+            'Commentaire'
+        ];
+        const factorsLabelById = new Map(getAggravatingFactors().map((factor) => [factor.id, factor.label]));
+        const rows = state.data.scenarios.map((scenario) => {
+            const risk = scenario.text || '';
+            const probability = clampMatrixValue(scenario.raw?.prob);
+            const impact = clampMatrixValue(scenario.raw?.impact);
+            const aggravatingFactors = (scenario.aggravatingFactors || [])
+                .map((id) => factorsLabelById.get(id) || id)
+                .join(' | ');
+            const effectiveness = `${nearestEffectivenessLevel(scenario.effectiveness)}% - ${effectivenessLabel(scenario.effectiveness)}`;
+            const comment = scenario.comment || '';
+
+            return [risk, probability, impact, aggravatingFactors, effectiveness, comment];
+        });
+
+        const csvContent = [header, ...rows]
+            .map((row) => row.map(csvEscape).join(','))
+            .join('\n');
+
+        const blob = new Blob([`\uFEFF${csvContent}`], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `cartographie-simplifiee-risques-${new Date().toISOString().slice(0, 10)}.csv`;
         a.click();
         URL.revokeObjectURL(url);
     }
@@ -529,6 +582,7 @@
         });
 
         dom.exportBtn.addEventListener('click', exportData);
+        dom.exportCsvBtn.addEventListener('click', exportCsvData);
         dom.importBtn.addEventListener('click', () => dom.importFile.click());
         dom.importFile.addEventListener('change', (evt) => {
             importDataFromFile(evt.target.files[0]);
@@ -536,12 +590,14 @@
         });
 
         window.addEventListener('resize', () => {
+            syncSimpleMatrixSquare();
             renderAssessment();
         });
 
         document.addEventListener('rms:tab-changed', (event) => {
             if (event?.detail?.tabName !== 'simple') return;
             requestAnimationFrame(() => {
+                syncSimpleMatrixSquare();
                 renderAssessment();
             });
         });
@@ -562,6 +618,7 @@
         dom.currentScenario = document.getElementById('simpleCurrentScenario');
         dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
         dom.matrix = document.getElementById('simpleMatrix');
+        dom.matrixWrapper = document.querySelector('.simple-edit-matrix');
         dom.rawLegend = document.getElementById('simpleRawLegend');
         dom.rawLegendDetail = document.getElementById('simpleRawLegendDetail');
         dom.legendProbabilityTitle = document.getElementById('simpleLegendProbabilityTitle');
@@ -579,6 +636,7 @@
         dom.prevBtn = document.getElementById('simplePrevBtn');
         dom.nextBtn = document.getElementById('simpleNextBtn');
         dom.exportBtn = document.getElementById('simpleExportBtn');
+        dom.exportCsvBtn = document.getElementById('simpleExportCsvBtn');
         dom.importBtn = document.getElementById('simpleImportBtn');
         dom.importFile = document.getElementById('simpleImportFile');
 
@@ -590,6 +648,7 @@
         ensureSelectedScenario();
 
         renderMatrix();
+        syncSimpleMatrixSquare();
         bindEvents();
         setView('scenarios');
         render();


### PR DESCRIPTION
### Motivation
- Release update to 2.1.23 with small feature additions and UI fixes for the simplified risk assessment mode.
- Provide a convenient CSV export for quick offline review or reporting of simplified scenarios.
- Ensure the simple-mode risk matrix stays square and renders correctly on resize and when switching tabs.

### Description
- Updated application version references and asset query strings from `2.1.22` to `2.1.23` in `CartoModel.html` and `simple-mode.js` to match the new release.
- Added an `Export CSV` button in the simple-mode toolbar and wired it to a new `exportCsvData()` function implemented in `assets/js/simple-mode.js` that builds a UTF-8 BOM CSV, escapes values, and downloads a file named `cartographie-simplifiee-risques-<date>.csv`.
- Implemented `csvEscape()` and CSV row assembly logic that exports `Risque`, `Probabilité`, `Impact`, `Facteurs aggravants`, `Efficacité des mesures`, and `Commentaire` for each scenario.
- Added `syncSimpleMatrixSquare()` and related DOM wiring (`dom.matrixWrapper`) and calls on resize, tab change, and when entering the assessment view to keep the matrix wrapper square and improve rendering stability.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81b581b28832ea7322544efd235ac)