### PR TITLE
Ajoute drag&drop fluide de la puce en vue simplifiée et mise à jour version 2.1.24

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.23</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.23">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.24</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.24">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -685,7 +685,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.23</span>
+            <span class="app-version">Version 2.1.24</span>
         </footer>
     </div>
 
@@ -1082,13 +1082,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js?v=2.1.23"></script>
-    <script defer src="assets/js/rms.constants.js?v=2.1.23"></script>
-    <script defer src="assets/js/rms.matrix.js?v=2.1.23"></script>
-    <script defer src="assets/js/rms.ui.js?v=2.1.23"></script>
-    <script defer src="assets/js/rms.core.js?v=2.1.23"></script>
-    <script defer src="assets/js/rms.integrations.js?v=2.1.23"></script>
-    <script defer src="assets/js/main.js?v=2.1.23"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.23"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.24"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.24"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.24"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.24"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.24"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.24"></script>
+    <script defer src="assets/js/main.js?v=2.1.24"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.24"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2510,7 +2510,7 @@ tbody tr:hover {
 
 .simple-matrix-layout {
     display: grid;
-    grid-template-columns: minmax(280px, 550px) minmax(240px, 1fr);
+    grid-template-columns: minmax(280px, 550px) minmax(255px, 1fr);
     gap: 16px;
     align-items: flex-start;
 }
@@ -2635,6 +2635,9 @@ tbody tr:hover {
 }
 
 .simple-edit-matrix .simple-cell-marker {
+    position: absolute;
+    top: 0;
+    left: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -2651,7 +2654,30 @@ tbody tr:hover {
     letter-spacing: 0;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.28);
     z-index: 5;
+    pointer-events: auto;
+    cursor: grab;
+    transition: transform 0.25s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.simple-edit-matrix .simple-cell-marker.no-transition {
+    transition: none;
+}
+
+.simple-edit-matrix .simple-cell-marker.is-dragging {
+    cursor: grabbing;
+    box-shadow: 0 0 0 7px rgba(29, 78, 216, 0.3), 0 7px 18px rgba(0, 0, 0, 0.32);
+    filter: saturate(1.05);
+}
+
+.simple-edit-matrix .simple-cell-marker.is-hidden {
+    opacity: 0;
     pointer-events: none;
+}
+
+.simple-edit-matrix .simple-matrix-cell.drag-hover {
+    border: 3px solid #0a3f74;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.9);
+    z-index: 2;
 }
 
 .simple-edit-matrix .axis-label {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.23',
+        version: '2.1.24',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -65,6 +65,11 @@
     };
 
     const dom = {};
+    const dragState = {
+        active: false,
+        pointerId: null,
+        pendingCell: null
+    };
 
     function cloneData(data) {
         if (typeof structuredClone === 'function') {
@@ -319,25 +324,93 @@
                 dom.matrix.appendChild(cell);
             }
         }
-
+        ensureSimpleMarker();
     }
 
-    function styleSimpleMarkerFallback(marker) {
-        marker.style.display = 'flex';
-        marker.style.alignItems = 'center';
-        marker.style.justifyContent = 'center';
-        marker.style.width = '34px';
-        marker.style.height = '34px';
-        marker.style.borderRadius = '50%';
-        marker.style.border = '2px solid #ffffff';
-        marker.style.boxShadow = '0 0 0 5px rgba(29, 78, 216, 0.35), 0 4px 12px rgba(0, 0, 0, 0.28)';
-        marker.style.background = 'linear-gradient(135deg, #4b91c5, #0061af)';
-        marker.style.color = '#ffffff';
-        marker.style.fontSize = '1.05rem';
-        marker.style.fontWeight = '700';
-        marker.style.lineHeight = '1';
-        marker.style.pointerEvents = 'none';
-        marker.style.zIndex = '5';
+    function getCellByCoordinates(clientX, clientY) {
+        if (!dom.matrix) return null;
+        const rect = dom.matrix.getBoundingClientRect();
+        if (!rect.width || !rect.height) return null;
+        if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom) return null;
+        const x = clientX - rect.left;
+        const y = clientY - rect.top;
+        const prob = Math.min(4, Math.max(1, Math.floor((x / rect.width) * 4) + 1));
+        const impact = Math.min(4, Math.max(1, 4 - Math.floor((y / rect.height) * 4)));
+        return { prob, impact };
+    }
+
+    function findSimpleCell(prob, impact) {
+        return dom.matrix?.querySelector(`.simple-matrix-cell[data-prob="${prob}"][data-impact="${impact}"]`) || null;
+    }
+
+    function setDragHoverCell(prob, impact) {
+        dom.matrix?.querySelectorAll('.simple-matrix-cell.drag-hover').forEach((cell) => cell.classList.remove('drag-hover'));
+        if (!prob || !impact) return;
+        findSimpleCell(prob, impact)?.classList.add('drag-hover');
+    }
+
+    function ensureSimpleMarker() {
+        if (!dom.matrixWrapper || dom.marker) return;
+        const marker = document.createElement('button');
+        marker.type = 'button';
+        marker.className = 'simple-cell-marker simple-cell-marker-floating';
+        marker.textContent = 'B';
+        marker.setAttribute('aria-label', 'Puce de position du risque');
+        marker.addEventListener('pointerdown', onMarkerPointerDown);
+        dom.matrixWrapper.appendChild(marker);
+        dom.marker = marker;
+    }
+
+    function placeMarker(prob, impact, animate = true) {
+        if (!dom.matrixWrapper || !dom.marker) return;
+        const cell = findSimpleCell(prob, impact);
+        if (!cell) return;
+        const cellRect = cell.getBoundingClientRect();
+        const wrapperRect = dom.matrixWrapper.getBoundingClientRect();
+        const x = cellRect.left - wrapperRect.left + (cellRect.width / 2);
+        const y = cellRect.top - wrapperRect.top + (cellRect.height / 2);
+        dom.marker.classList.toggle('no-transition', !animate);
+        dom.marker.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px) translate(-50%, -50%)`;
+    }
+
+    function onMarkerPointerDown(event) {
+        const scenario = getSelectedScenario();
+        if (!scenario || !dom.marker) return;
+        dragState.active = true;
+        dragState.pointerId = event.pointerId;
+        dragState.pendingCell = { ...scenario.raw };
+        dom.marker.classList.add('is-dragging');
+        dom.marker.setPointerCapture(event.pointerId);
+        event.preventDefault();
+    }
+
+    function onGlobalPointerMove(event) {
+        if (!dragState.active || dragState.pointerId !== event.pointerId) return;
+        const cell = getCellByCoordinates(event.clientX, event.clientY);
+        if (!cell) return;
+        dragState.pendingCell = cell;
+        placeMarker(cell.prob, cell.impact, false);
+        setDragHoverCell(cell.prob, cell.impact);
+    }
+
+    function onGlobalPointerUp(event) {
+        if (!dragState.active || dragState.pointerId !== event.pointerId) return;
+        if (dom.marker?.hasPointerCapture(event.pointerId)) {
+            dom.marker.releasePointerCapture(event.pointerId);
+        }
+        dragState.active = false;
+        dragState.pointerId = null;
+        dom.marker?.classList.remove('is-dragging');
+        const cell = getCellByCoordinates(event.clientX, event.clientY) || dragState.pendingCell;
+        setDragHoverCell(null, null);
+
+        if (cell) {
+            updateCurrentScenario({ raw: { prob: cell.prob, impact: cell.impact } });
+        } else {
+            const scenario = getSelectedScenario();
+            if (scenario) placeMarker(scenario.raw.prob, scenario.raw.impact);
+        }
+        dragState.pendingCell = null;
     }
 
     function renderAssessment() {
@@ -353,6 +426,7 @@
         renderAggravatingFactors(scenario);
 
         if (!scenario) {
+            if (dom.marker) dom.marker.classList.add('is-hidden');
             dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
             dom.rawLegendDetail.textContent = 'Chargez des scénarios pour commencer la cotation.';
             renderLegendDescription(1, 1);
@@ -363,6 +437,7 @@
         }
 
         const { prob, impact } = scenario.raw;
+        if (dom.marker) dom.marker.classList.remove('is-hidden');
         const score = prob * impact;
         dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
         dom.rawLegendDetail.textContent = `Probabilité: ${prob}/4 • Impact: ${impact}/4`;
@@ -370,17 +445,8 @@
         dom.matrix.querySelectorAll('.simple-matrix-cell').forEach((cell) => {
             const isActive = Number(cell.dataset.prob) === prob && Number(cell.dataset.impact) === impact;
             cell.classList.toggle('active-cell', isActive);
-            cell.innerHTML = '';
-
-            if (isActive) {
-                const marker = document.createElement('span');
-                marker.className = 'simple-cell-marker';
-                marker.textContent = 'B';
-                marker.setAttribute('aria-label', 'Puce de position du risque');
-                styleSimpleMarkerFallback(marker);
-                cell.appendChild(marker);
-            }
         });
+        placeMarker(prob, impact, !dragState.active);
 
         const snappedEffectiveness = nearestEffectivenessLevel(scenario.effectiveness);
         if (snappedEffectiveness !== scenario.effectiveness) {
@@ -593,6 +659,9 @@
             syncSimpleMatrixSquare();
             renderAssessment();
         });
+        window.addEventListener('pointermove', onGlobalPointerMove);
+        window.addEventListener('pointerup', onGlobalPointerUp);
+        window.addEventListener('pointercancel', onGlobalPointerUp);
 
         document.addEventListener('rms:tab-changed', (event) => {
             if (event?.detail?.tabName !== 'simple') return;


### PR DESCRIPTION
### Motivation
- Permettre le déplacement direct de la puce sur la matrice de la vue simplifiée avec une interaction tactile/ponctuelle moderne et une animation douce entre cases.
- Améliorer le feedback visuel pendant le déplacement (surbrillance de la case survolée) pour réduire les erreurs d'usage.
- Ajuster légèrement l'espace de la légende droite pour mieux accueillir le marqueur flottant.
- Mettre à jour le numéro de version demandé dans le footer et les ressources cache-busting à `2.1.24`.

### Description
- Ajout d'un marqueur flottant unique et animée dans `assets/js/simple-mode.js` avec la gestion Pointer (`pointerdown`, `pointermove`, `pointerup`) et capture de pointeur, détection de la cellule sous le pointeur et application de la nouvelle position au relâchement.
- Remplacement de la génération locale de la puce dans la cellule par une puce flottante repositionnée via `transform` pour obtenir un mouvement doux, et gestion des états CSS (`is-dragging`, `no-transition`, `is-hidden`) pour le rendu pendant/avant/après le drag.
- Ajout de logique utilitaire pour convertir des coordonnées en case (`getCellByCoordinates`), surbrillance de la case cible (`drag-hover`) et recentrage du marqueur (`placeMarker`).
- Ajustements CSS dans `assets/css/main.css` pour élargir légèrement la colonne de légende à droite, positionner le marqueur en absolu et ajouter transitions/états visuels; mise à jour du HTML `CartoModel.html` et des query strings pour propager la nouvelle version.

### Testing
- Vérification statique JavaScript via `node --check assets/js/simple-mode.js` : succès.
- Validation rapide des fichiers modifiés et commit Git : commit créé avec les trois fichiers modifiés (`CartoModel.html`, `assets/css/main.css`, `assets/js/simple-mode.js`).
- Aucune suite de tests unitaires automatisée fournie dans le projet pour cette modification ; comportement visuel à valider en navigateur (manuellement) si nécessaire.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81d745894832ebc4b9b4b1e77e28c)