### PR TITLE
Fix export CSV simplifié : utiliser « ; » comme séparateur et incrémenter la version

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -685,7 +685,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.24</span>
+            <span class="app-version">Version 2.1.25</span>
         </footer>
     </div>
 
@@ -1089,6 +1089,6 @@ Cadeau inapproprié à un agent public"></textarea>
     <script defer src="assets/js/rms.core.js?v=2.1.24"></script>
     <script defer src="assets/js/rms.integrations.js?v=2.1.24"></script>
     <script defer src="assets/js/main.js?v=2.1.24"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.24"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.25"></script>
 </body>
 </html>

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.24',
+        version: '2.1.25',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -551,7 +551,7 @@
     function csvEscape(value) {
         const stringValue = String(value ?? '');
         const escaped = stringValue.replace(/"/g, '""');
-        if (/[",\n]/.test(escaped)) {
+        if (/[";\n]/.test(escaped)) {
             return `"${escaped}"`;
         }
         return escaped;
@@ -581,7 +581,7 @@
         });
 
         const csvContent = [header, ...rows]
-            .map((row) => row.map(csvEscape).join(','))
+            .map((row) => row.map(csvEscape).join(';'))
             .join('\n');
 
         const blob = new Blob([`\uFEFF${csvContent}`], { type: 'text/csv;charset=utf-8;' });


### PR DESCRIPTION
### Motivation
- L'export CSV de la version simplifiée doit utiliser le point-virgule (`;`) comme délimiteur pour compatibilité avec les environnements francophones.
- Le footer et la version interne du mode simplifié doivent être incrémentés conformément à la règle de versionnement du projet, mise à `2.1.25`.

### Description
- Change le séparateur CSV dans `assets/js/simple-mode.js` en joignant les colonnes avec `;` au lieu de `,` dans `exportCsvData()`.
- Adapte `csvEscape()` pour détecter et entourer de guillemets les champs contenant `;`, `"` ou un saut de ligne.`
- Met à jour la `DEFAULT_DATA.version` dans `assets/js/simple-mode.js` à `2.1.25`.
- Met à jour le footer affiché dans `CartoModel.html` et le paramètre de cache-busting du script `simple-mode.js` vers `v=2.1.25`.

### Testing
- Exécution de `node -e "new Function(require('fs').readFileSync('/workspace/cartographie/assets/js/simple-mode.js','utf8')); console.log('simple-mode.js ok')"` a réussi et a chargé le fichier modifié sans erreur.
- Aucune autre suite de tests automatisés n'a été exécutée dans cet environnement (tests navigateur non disponibles ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81f20ef20832eb41b0b730e150a72)