### PR TITLE
Mode simplifié : déplacer facteurs aggravants, suppression par scénario et mise à jour version 2.1.26

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.24</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.24">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.26</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.26">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -266,10 +266,6 @@ Cadeau inapproprié à un agent public"></textarea>
                                     <div class="matrix-description-header">Risque brut</div>
                                     <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
                                     <div class="simple-legend-sub" id="simpleRawLegendDetail">Sélectionnez une case pour afficher la cotation détaillée.</div>
-                                    <div class="simple-aggravating-factors">
-                                        <h4>Facteurs aggravants</h4>
-                                        <div id="simpleAggravatingFactors" class="simple-aggravating-list"></div>
-                                    </div>
                                     <div class="simple-legend-description">
                                         <div class="simple-legend-block">
                                             <h4 id="simpleLegendProbabilityTitle">Probabilité 1 – Peu probable</h4>
@@ -279,6 +275,10 @@ Cadeau inapproprié à un agent public"></textarea>
                                         <div class="simple-legend-block">
                                             <h4 id="simpleLegendImpactTitle">Impact 1 – Faible</h4>
                                             <ul id="simpleLegendImpactBullets" class="simple-legend-bullets"></ul>
+                                        </div>
+                                        <div class="simple-aggravating-factors">
+                                            <h4>Facteurs aggravants</h4>
+                                            <div id="simpleAggravatingFactors" class="simple-aggravating-list"></div>
                                         </div>
                                     </div>
                                 </div>
@@ -685,7 +685,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.25</span>
+            <span class="app-version">Version 2.1.26</span>
         </footer>
     </div>
 
@@ -1082,13 +1082,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js?v=2.1.24"></script>
-    <script defer src="assets/js/rms.constants.js?v=2.1.24"></script>
-    <script defer src="assets/js/rms.matrix.js?v=2.1.24"></script>
-    <script defer src="assets/js/rms.ui.js?v=2.1.24"></script>
-    <script defer src="assets/js/rms.core.js?v=2.1.24"></script>
-    <script defer src="assets/js/rms.integrations.js?v=2.1.24"></script>
-    <script defer src="assets/js/main.js?v=2.1.24"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.25"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.26"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.26"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.26"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.26"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.26"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.26"></script>
+    <script defer src="assets/js/main.js?v=2.1.26"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.26"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2455,6 +2455,13 @@ tbody tr:hover {
     gap: 8px;
 }
 
+.simple-scenario-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: stretch;
+}
+
 .simple-scenario-item {
     text-align: left;
     border: 1px solid #dfe4ea;
@@ -2466,6 +2473,27 @@ tbody tr:hover {
 
 .simple-scenario-item.active {
     border-color: var(--primary-color);
+    background: #fff9f1;
+}
+
+.simple-scenario-delete {
+    border: 1px solid #dfe4ea;
+    background: #fff;
+    border-radius: 10px;
+    min-width: 44px;
+    color: #b42318;
+    cursor: pointer;
+    font-size: 1.1rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.simple-scenario-delete:hover {
+    background: #fff1f0;
+    border-color: #f1b5af;
+}
+
+.simple-scenario-row.active .simple-scenario-delete {
+    border-color: #f2d1a2;
     background: #fff9f1;
 }
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.25',
+        version: '2.1.26',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -253,6 +253,24 @@
         saveLocal();
     }
 
+    function deleteScenario(id) {
+        const index = state.data.scenarios.findIndex((scenario) => scenario.id === id);
+        if (index === -1) return;
+
+        const wasSelected = state.data.selectedId === id;
+        state.data.scenarios.splice(index, 1);
+
+        if (wasSelected) {
+            const fallback = state.data.scenarios[index] || state.data.scenarios[index - 1] || null;
+            state.data.selectedId = fallback?.id || null;
+        } else {
+            ensureSelectedScenario();
+        }
+
+        render();
+        saveLocal();
+    }
+
     function updateCurrentScenario(patch) {
         const current = getSelectedScenario();
         if (!current) return;
@@ -297,12 +315,26 @@
         }
 
         state.data.scenarios.forEach((scenario, index) => {
+            const row = document.createElement('div');
+            row.className = `simple-scenario-row ${scenario.id === state.data.selectedId ? 'active' : ''}`;
+
             const button = document.createElement('button');
             button.type = 'button';
             button.className = `simple-scenario-item ${scenario.id === state.data.selectedId ? 'active' : ''}`;
             button.innerHTML = `<span>${index + 1}. ${scenario.text}</span>`;
             button.addEventListener('click', () => selectScenario(scenario.id));
-            dom.scenarioList.appendChild(button);
+
+            const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
+            deleteButton.className = 'simple-scenario-delete';
+            deleteButton.setAttribute('aria-label', `Supprimer le scénario ${index + 1}`);
+            deleteButton.title = 'Supprimer ce scénario';
+            deleteButton.textContent = '🗑️';
+            deleteButton.addEventListener('click', () => deleteScenario(scenario.id));
+
+            row.appendChild(button);
+            row.appendChild(deleteButton);
+            dom.scenarioList.appendChild(row);
         });
     }
 


### PR DESCRIPTION
### Motivation
- Répondre à la demande d'UI pour la `Version simplifiée` en repositionnant le bloc des facteurs aggravants sous la légende d'impact et permettre la suppression unitaire de scénarios chargés. 
- Mettre à jour le numéro de version dans le footer et les assets conformément à la règle de versionnement demandée (nouvelle version : `2.1.26`).

### Description
- Déplacé le bloc HTML des `Facteurs aggravants` dans `CartoModel.html` pour qu'il apparaisse sous la légende d'`Impact` dans la vue simplifiée. 
- Ajouté la fonction `deleteScenario(id)` dans `assets/js/simple-mode.js` qui supprime un scénario et gère correctement la sélection/fallback après suppression. 
- Modifié `renderScenarioList` pour rendre chaque scénario comme une ligne contenant un bouton de sélection et un bouton corbeille `🗑️`, et ajouté le texte d'attribut/accessibilité pour le bouton de suppression. 
- Ajouté des styles CSS (`.simple-scenario-row`, `.simple-scenario-delete`) dans `assets/css/main.css` et mis à jour la version affichée et les paramètres `?v=` pour les assets et la `DEFAULT_DATA.version` à `2.1.26` dans `assets/js/simple-mode.js`.

### Testing
- Exécuté la vérification de syntaxe JavaScript avec `node --check assets/js/simple-mode.js`, qui a réussi (`JS syntax OK`).
- Aucun autre test automatisé disponible dans cet environnement; rendu visuel et interaction manuelle non automatisés n'ont pas été exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a826416c832e8f09a86c03fcb91d)