### PR TITLE
Ajout d’un onglet « Vue consolidée » des risques bruts en version simplifiée — mise à jour v2.1.28

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.27</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.27">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.28</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.28">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -226,6 +226,7 @@
                     <div class="simple-subtabs">
                         <button class="simple-subtab active" data-simple-view="scenarios">1. Chargement des scénarios</button>
                         <button class="simple-subtab" data-simple-view="assessment">2. Cotation</button>
+                        <button class="simple-subtab" data-simple-view="overview">3. Vue consolidée</button>
                     </div>
 
                     <section class="simple-panel active" id="simple-scenarios-panel">
@@ -298,6 +299,26 @@ Cadeau inapproprié à un agent public"></textarea>
                         <div class="simple-nav-actions">
                             <button class="btn btn-secondary" id="simplePrevBtn">← Scénario précédent</button>
                             <button class="btn btn-primary" id="simpleNextBtn">Scénario suivant →</button>
+                        </div>
+                    </section>
+
+                    <section class="simple-panel" id="simple-overview-panel">
+                        <div class="simple-overview-layout">
+                            <div class="simple-overview-list-card">
+                                <h3>Risques bruts triés (P × I décroissant)</h3>
+                                <div id="simpleOverviewRiskList" class="simple-overview-risk-list"></div>
+                            </div>
+                            <div class="simple-overview-matrix-card">
+                                <h3>Matrice des risques bruts</h3>
+                                <div class="matrix simple-overview-matrix-wrapper">
+                                    <div class="matrix-grid simple-overview-matrix" id="simpleOverviewMatrix"></div>
+                                    <div class="axis-label x-axis">Probabilité →</div>
+                                    <div class="axis-label y-axis">
+                                        <span class="axis-text">Impact</span>
+                                        <span class="axis-arrow" aria-hidden="true">↑</span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </section>
                 </div>
@@ -685,7 +706,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.27</span>
+            <span class="app-version">Version 2.1.28</span>
         </footer>
     </div>
 
@@ -1082,13 +1103,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js?v=2.1.27"></script>
-    <script defer src="assets/js/rms.constants.js?v=2.1.27"></script>
-    <script defer src="assets/js/rms.matrix.js?v=2.1.27"></script>
-    <script defer src="assets/js/rms.ui.js?v=2.1.27"></script>
-    <script defer src="assets/js/rms.core.js?v=2.1.27"></script>
-    <script defer src="assets/js/rms.integrations.js?v=2.1.27"></script>
-    <script defer src="assets/js/main.js?v=2.1.27"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.27"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.28"></script>
+    <script defer src="assets/js/main.js?v=2.1.28"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.28"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2409,6 +2409,7 @@ tbody tr:hover {
     display: flex;
     gap: 10px;
     margin-bottom: 20px;
+    flex-wrap: wrap;
 }
 
 .simple-subtab {
@@ -2756,8 +2757,117 @@ tbody tr:hover {
     background: #fff;
 }
 
+.simple-overview-layout {
+    display: grid;
+    grid-template-columns: minmax(300px, 0.95fr) minmax(360px, 1.05fr);
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.simple-overview-list-card,
+.simple-overview-matrix-card {
+    border: 1px solid #ecf0f1;
+    border-radius: 12px;
+    padding: 14px;
+    background: #fff;
+}
+
+.simple-overview-list-card h3,
+.simple-overview-matrix-card h3 {
+    margin: 0 0 12px;
+    font-size: 1.02rem;
+}
+
+.simple-overview-risk-list {
+    display: grid;
+    gap: 8px;
+    max-height: 520px;
+    overflow: auto;
+}
+
+.simple-overview-item {
+    border: 1px solid #dfe4ea;
+    border-radius: 10px;
+    padding: 10px;
+    background: #fff;
+    text-align: left;
+    cursor: pointer;
+}
+
+.simple-overview-item.active {
+    border-color: #1766ae;
+    background: #eaf4ff;
+    box-shadow: inset 0 0 0 1px rgba(23, 102, 174, 0.25);
+}
+
+.simple-overview-item-title {
+    display: block;
+    font-weight: 600;
+    color: #233445;
+}
+
+.simple-overview-item-meta {
+    display: block;
+    margin-top: 4px;
+    color: #597185;
+    font-size: 0.92rem;
+}
+
+.simple-overview-matrix-wrapper {
+    width: min(520px, 100%);
+    max-width: 100%;
+    aspect-ratio: 1 / 1;
+    border: 1px solid #8ea8c5;
+    border-radius: 10px;
+    box-shadow: 0 8px 22px rgba(25, 54, 88, 0.08);
+    background: #ffffff;
+}
+
+.simple-overview-matrix {
+    border: 1px solid #f0b74f;
+}
+
+.simple-overview-matrix .simple-overview-cell {
+    border: 1px solid #c6d7ea;
+    position: relative;
+}
+
+.simple-overview-bullet {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 1px solid #ffffff;
+    background: #1967d2;
+    color: #ffffff;
+    font-size: 0.66rem;
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(15, 42, 74, 0.35);
+}
+
+.simple-overview-bullet.active {
+    background: #c81e1e;
+    transform: scale(1.16);
+    z-index: 3;
+}
+
+.simple-overview-empty {
+    padding: 12px;
+    border: 1px dashed #cfd8df;
+    border-radius: 10px;
+    color: #7b8794;
+}
+
 @media (max-width: 980px) {
     .simple-matrix-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .simple-overview-layout {
         grid-template-columns: 1fr;
     }
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.27',
+        version: '2.1.28',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -61,7 +61,8 @@
 
     const state = {
         data: cloneData(DEFAULT_DATA),
-        view: 'scenarios'
+        view: 'scenarios',
+        highlightedScenarioId: null
     };
 
     const dom = {};
@@ -200,6 +201,7 @@
     function ensureSelectedScenario() {
         if (!state.data.scenarios.length) {
             state.data.selectedId = null;
+            state.highlightedScenarioId = null;
             return null;
         }
 
@@ -207,12 +209,16 @@
         if (!hasSelectedScenario) {
             state.data.selectedId = state.data.scenarios[0].id;
         }
+        if (!state.data.scenarios.some((scenario) => scenario.id === state.highlightedScenarioId)) {
+            state.highlightedScenarioId = state.data.selectedId;
+        }
 
         return state.data.selectedId;
     }
 
     function selectScenario(id) {
         state.data.selectedId = id;
+        state.highlightedScenarioId = id;
         render();
         saveLocal();
     }
@@ -232,6 +238,7 @@
             comment: ''
         }));
         state.data.selectedId = state.data.scenarios[0]?.id || null;
+        state.highlightedScenarioId = state.data.selectedId;
         render();
         saveLocal();
     }
@@ -249,6 +256,7 @@
         const index = state.data.scenarios.findIndex((s) => s.id === current.id);
         state.data.scenarios.splice(index + 1, 0, cloned);
         state.data.selectedId = cloned.id;
+        state.highlightedScenarioId = cloned.id;
         render();
         saveLocal();
     }
@@ -263,6 +271,7 @@
         if (wasSelected) {
             const fallback = state.data.scenarios[index] || state.data.scenarios[index - 1] || null;
             state.data.selectedId = fallback?.id || null;
+            state.highlightedScenarioId = state.data.selectedId;
         } else {
             ensureSelectedScenario();
         }
@@ -291,8 +300,24 @@
         const index = scenarios.findIndex((s) => s.id === state.data.selectedId);
         const nextIndex = Math.min(scenarios.length - 1, Math.max(0, index + step));
         state.data.selectedId = scenarios[nextIndex].id;
+        state.highlightedScenarioId = state.data.selectedId;
         render();
         saveLocal();
+    }
+
+    function getSortedScenariosByRawRisk() {
+        return [...state.data.scenarios].sort((left, right) => {
+            const leftProb = clampMatrixValue(left.raw?.prob);
+            const leftImpact = clampMatrixValue(left.raw?.impact);
+            const rightProb = clampMatrixValue(right.raw?.prob);
+            const rightImpact = clampMatrixValue(right.raw?.impact);
+            const leftScore = leftProb * leftImpact;
+            const rightScore = rightProb * rightImpact;
+            if (rightScore !== leftScore) return rightScore - leftScore;
+            if (rightImpact !== leftImpact) return rightImpact - leftImpact;
+            if (rightProb !== leftProb) return rightProb - leftProb;
+            return left.text.localeCompare(right.text, 'fr');
+        });
     }
 
     function scoreLabel(score) {
@@ -493,6 +518,92 @@
         dom.nextBtn.disabled = idx >= state.data.scenarios.length - 1;
     }
 
+    function setHighlightedScenario(id, options = {}) {
+        const { syncSelection = true, persist = false } = options;
+        if (!id || !state.data.scenarios.some((scenario) => scenario.id === id)) return;
+        state.highlightedScenarioId = id;
+        if (syncSelection) {
+            state.data.selectedId = id;
+        }
+        renderOverview();
+        if (syncSelection) {
+            renderScenarioList();
+            if (state.view === 'assessment') {
+                renderAssessment();
+            }
+        }
+        if (persist) {
+            saveLocal();
+        }
+    }
+
+    function renderOverview() {
+        if (!dom.overviewRiskList || !dom.overviewMatrix) return;
+        const scenarios = getSortedScenariosByRawRisk();
+
+        dom.overviewRiskList.innerHTML = '';
+        dom.overviewMatrix.innerHTML = '';
+
+        if (!scenarios.length) {
+            dom.overviewRiskList.innerHTML = '<div class="simple-overview-empty">Aucun risque coté pour le moment.</div>';
+            dom.overviewMatrix.innerHTML = '<div class="simple-overview-empty">Chargez des scénarios pour afficher la matrice consolidée.</div>';
+            return;
+        }
+
+        const indexByScenarioId = new Map(scenarios.map((scenario, index) => [scenario.id, index + 1]));
+        const highlightedId = state.highlightedScenarioId || state.data.selectedId || scenarios[0].id;
+
+        scenarios.forEach((scenario, index) => {
+            const score = scenario.raw.prob * scenario.raw.impact;
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `simple-overview-item ${scenario.id === highlightedId ? 'active' : ''}`;
+            button.innerHTML = `
+                <span class="simple-overview-item-title">${index + 1}. ${scenario.text}</span>
+                <span class="simple-overview-item-meta">Score ${score} • P${scenario.raw.prob} × I${scenario.raw.impact}</span>
+            `;
+            button.addEventListener('click', () => setHighlightedScenario(scenario.id, { syncSelection: true, persist: true }));
+            dom.overviewRiskList.appendChild(button);
+        });
+
+        for (let impact = 4; impact >= 1; impact -= 1) {
+            for (let prob = 1; prob <= 4; prob += 1) {
+                const cell = document.createElement('div');
+                const score = prob * impact;
+                cell.className = `matrix-cell simple-overview-cell level-${scoreToLevel(score)}`;
+                const risksInCell = scenarios.filter((scenario) => scenario.raw.prob === prob && scenario.raw.impact === impact);
+
+                const spacing = 23;
+                const perRow = 4;
+                risksInCell.forEach((scenario, riskIndex) => {
+                    const bullet = document.createElement('button');
+                    bullet.type = 'button';
+                    bullet.className = `simple-overview-bullet ${scenario.id === highlightedId ? 'active' : ''}`;
+                    bullet.title = scenario.text;
+                    bullet.setAttribute('aria-label', `Risque ${indexByScenarioId.get(scenario.id)}: ${scenario.text}`);
+                    bullet.textContent = String(indexByScenarioId.get(scenario.id));
+                    const row = Math.floor(riskIndex / perRow);
+                    const col = riskIndex % perRow;
+                    bullet.style.top = `${8 + (row * spacing)}px`;
+                    bullet.style.left = `${8 + (col * spacing)}px`;
+                    bullet.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        setHighlightedScenario(scenario.id, { syncSelection: true, persist: true });
+                    });
+                    cell.appendChild(bullet);
+                });
+
+                cell.addEventListener('click', () => {
+                    const firstRisk = risksInCell[0];
+                    if (firstRisk) {
+                        setHighlightedScenario(firstRisk.id, { syncSelection: true, persist: true });
+                    }
+                });
+                dom.overviewMatrix.appendChild(cell);
+            }
+        }
+    }
+
     function renderAggravatingFactors(scenario) {
         if (!dom.aggravatingFactorsList) return;
         dom.aggravatingFactorsList.innerHTML = '';
@@ -560,11 +671,18 @@
         });
         dom.scenariosPanel.classList.toggle('active', viewName === 'scenarios');
         dom.assessmentPanel.classList.toggle('active', viewName === 'assessment');
+        dom.overviewPanel.classList.toggle('active', viewName === 'overview');
 
         if (viewName === 'assessment') {
             requestAnimationFrame(() => {
                 syncSimpleMatrixSquare();
                 renderAssessment();
+            });
+            return;
+        }
+        if (viewName === 'overview') {
+            requestAnimationFrame(() => {
+                renderOverview();
             });
         }
     }
@@ -650,6 +768,7 @@
                 state.data.selectedId = parsed.selectedId && state.data.scenarios.some((s) => s.id === parsed.selectedId)
                     ? parsed.selectedId
                     : state.data.scenarios[0]?.id || null;
+                state.highlightedScenarioId = state.data.selectedId;
                 render();
                 saveLocal();
             } catch (error) {
@@ -708,6 +827,7 @@
         ensureSelectedScenario();
         renderScenarioList();
         renderAssessment();
+        renderOverview();
     }
 
     function init() {
@@ -716,6 +836,7 @@
         dom.scenarioList = document.getElementById('simpleScenarioList');
         dom.scenariosPanel = document.getElementById('simple-scenarios-panel');
         dom.assessmentPanel = document.getElementById('simple-assessment-panel');
+        dom.overviewPanel = document.getElementById('simple-overview-panel');
         dom.currentScenario = document.getElementById('simpleCurrentScenario');
         dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
         dom.matrix = document.getElementById('simpleMatrix');
@@ -740,6 +861,8 @@
         dom.exportCsvBtn = document.getElementById('simpleExportCsvBtn');
         dom.importBtn = document.getElementById('simpleImportBtn');
         dom.importFile = document.getElementById('simpleImportFile');
+        dom.overviewRiskList = document.getElementById('simpleOverviewRiskList');
+        dom.overviewMatrix = document.getElementById('simpleOverviewMatrix');
 
         if (!dom.scenariosInput || !dom.matrix) {
             return;
@@ -747,6 +870,7 @@
 
         loadLocal();
         ensureSelectedScenario();
+        state.highlightedScenarioId = state.data.selectedId;
 
         renderMatrix();
         syncSimpleMatrixSquare();


### PR DESCRIPTION
### Motivation
- Fournir une vue consolidée dans la version simplifiée pour visualiser rapidement l’ensemble des risques bruts triés et leur position dans la matrice afin de faciliter la revue et la priorisation.
- Respecter la consigne d’incrémenter la version du footer et des assets à chaque tâche (mise à jour vers `2.1.28`).

### Description
- Ajoute un 3ᵉ sous-onglet « Vue consolidée » dans la page de la version simplifiée avec un nouveau panneau HTML (gauche : liste triée, droite : matrice avec puces). (modifications dans `CartoModel.html`).
- Implémente le tri par risque brut (Probabilité × Impact), la génération des puces sur la matrice et la synchronisation bidirectionnelle liste ↔ puce, ainsi que la persistance optionnelle du surlignage ; nouveaux helpers et rendu dans `assets/js/simple-mode.js` (`highlightedScenarioId`, `getSortedScenariosByRawRisk`, `renderOverview`, `setHighlightedScenario`).
- Ajoute le CSS nécessaire pour l’affichage deux colonnes, la grille de la matrice consolidée, les puces cliquables et les états actifs, avec adaptation responsive (modifications dans `assets/css/main.css`).
- Met à jour la version applicative et les références d’assets à `2.1.28` (titre, footer et query strings des scripts) et la valeur `DEFAULT_DATA.version` dans `simple-mode.js`.

### Testing
- Exécuté `node --check assets/js/simple-mode.js` pour valider la syntaxe JavaScript et le fichier est correct (succès).
- Aucune suite de tests navigateur automatisée disponible ici, rendu visuel et interactions à valider en environnement navigateur (manuellement ou via tests E2E ultérieurs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d655b1c8832e9e8af41fa3e791fe)