### PR TITLE
Ajout des titres de niveaux sur la matrice consolidée (version simplifiée)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.28</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.28">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.29</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.29">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -310,14 +310,18 @@ Cadeau inapproprié à un agent public"></textarea>
                             </div>
                             <div class="simple-overview-matrix-card">
                                 <h3>Matrice des risques bruts</h3>
-                                <div class="matrix simple-overview-matrix-wrapper">
-                                    <div class="matrix-grid simple-overview-matrix" id="simpleOverviewMatrix"></div>
-                                    <div class="axis-label x-axis">Probabilité →</div>
-                                    <div class="axis-label y-axis">
-                                        <span class="axis-text">Impact</span>
-                                        <span class="axis-arrow" aria-hidden="true">↑</span>
+                                <div class="simple-overview-matrix-shell">
+                                    <div class="simple-overview-impact-labels" id="simpleOverviewImpactLabels"></div>
+                                    <div class="matrix simple-overview-matrix-wrapper">
+                                        <div class="matrix-grid simple-overview-matrix" id="simpleOverviewMatrix"></div>
+                                        <div class="axis-label x-axis">Probabilité →</div>
+                                        <div class="axis-label y-axis">
+                                            <span class="axis-text">Impact</span>
+                                            <span class="axis-arrow" aria-hidden="true">↑</span>
+                                        </div>
                                     </div>
                                 </div>
+                                <div class="simple-overview-probability-labels" id="simpleOverviewProbabilityLabels"></div>
                             </div>
                         </div>
                     </section>
@@ -706,7 +710,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.28</span>
+            <span class="app-version">Version 2.1.29</span>
         </footer>
     </div>
 
@@ -1103,13 +1107,13 @@ Cadeau inapproprié à un agent public"></textarea>
         </div>
     </div>
 
-    <script defer src="assets/js/rms.utils.js?v=2.1.28"></script>
-    <script defer src="assets/js/rms.constants.js?v=2.1.28"></script>
-    <script defer src="assets/js/rms.matrix.js?v=2.1.28"></script>
-    <script defer src="assets/js/rms.ui.js?v=2.1.28"></script>
-    <script defer src="assets/js/rms.core.js?v=2.1.28"></script>
-    <script defer src="assets/js/rms.integrations.js?v=2.1.28"></script>
-    <script defer src="assets/js/main.js?v=2.1.28"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.28"></script>
+    <script defer src="assets/js/rms.utils.js?v=2.1.29"></script>
+    <script defer src="assets/js/rms.constants.js?v=2.1.29"></script>
+    <script defer src="assets/js/rms.matrix.js?v=2.1.29"></script>
+    <script defer src="assets/js/rms.ui.js?v=2.1.29"></script>
+    <script defer src="assets/js/rms.core.js?v=2.1.29"></script>
+    <script defer src="assets/js/rms.integrations.js?v=2.1.29"></script>
+    <script defer src="assets/js/main.js?v=2.1.29"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.29"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2823,6 +2823,48 @@ tbody tr:hover {
     background: #ffffff;
 }
 
+.simple-overview-matrix-shell {
+    display: grid;
+    grid-template-columns: minmax(84px, auto) minmax(0, 1fr);
+    align-items: stretch;
+    gap: 10px;
+}
+
+.simple-overview-impact-labels {
+    display: grid;
+    grid-template-rows: repeat(4, 1fr);
+    gap: 2px;
+    padding: 2px 0;
+}
+
+.simple-overview-probability-labels {
+    margin-top: 8px;
+    padding-left: 94px;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 2px;
+}
+
+.simple-overview-axis-level {
+    font-size: 0.78rem;
+    color: #2f4154;
+    line-height: 1.2;
+    font-weight: 600;
+}
+
+.simple-overview-axis-level.y-level {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    text-align: right;
+    padding-right: 6px;
+}
+
+.simple-overview-axis-level.x-level {
+    text-align: center;
+    padding: 0 4px;
+}
+
 .simple-overview-matrix {
     border: 1px solid #f0b74f;
 }
@@ -2869,6 +2911,15 @@ tbody tr:hover {
 
     .simple-overview-layout {
         grid-template-columns: 1fr;
+    }
+
+    .simple-overview-matrix-shell {
+        grid-template-columns: 74px minmax(0, 1fr);
+        gap: 8px;
+    }
+
+    .simple-overview-probability-labels {
+        padding-left: 82px;
     }
 
     .simple-aggravating-list {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.28',
+        version: '2.1.29',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -540,9 +540,31 @@
     function renderOverview() {
         if (!dom.overviewRiskList || !dom.overviewMatrix) return;
         const scenarios = getSortedScenariosByRawRisk();
+        const impactLevels = [4, 3, 2, 1];
+        const probabilityLevels = [1, 2, 3, 4];
 
         dom.overviewRiskList.innerHTML = '';
         dom.overviewMatrix.innerHTML = '';
+        if (dom.overviewImpactLabels) dom.overviewImpactLabels.innerHTML = '';
+        if (dom.overviewProbabilityLabels) dom.overviewProbabilityLabels.innerHTML = '';
+
+        if (dom.overviewImpactLabels) {
+            impactLevels.forEach((impact) => {
+                const label = document.createElement('div');
+                label.className = 'simple-overview-axis-level y-level';
+                label.textContent = IMPACT_LEGEND[impact]?.title || `Impact ${impact}`;
+                dom.overviewImpactLabels.appendChild(label);
+            });
+        }
+
+        if (dom.overviewProbabilityLabels) {
+            probabilityLevels.forEach((probability) => {
+                const label = document.createElement('div');
+                label.className = 'simple-overview-axis-level x-level';
+                label.textContent = PROBABILITY_LEGEND[probability]?.title || `Probabilité ${probability}`;
+                dom.overviewProbabilityLabels.appendChild(label);
+            });
+        }
 
         if (!scenarios.length) {
             dom.overviewRiskList.innerHTML = '<div class="simple-overview-empty">Aucun risque coté pour le moment.</div>';
@@ -863,6 +885,8 @@
         dom.importFile = document.getElementById('simpleImportFile');
         dom.overviewRiskList = document.getElementById('simpleOverviewRiskList');
         dom.overviewMatrix = document.getElementById('simpleOverviewMatrix');
+        dom.overviewImpactLabels = document.getElementById('simpleOverviewImpactLabels');
+        dom.overviewProbabilityLabels = document.getElementById('simpleOverviewProbabilityLabels');
 
         if (!dom.scenariosInput || !dom.matrix) {
             return;


### PR DESCRIPTION
### Motivation
- Améliorer la lisibilité de la vue consolidée de la "Version simplifiée" en affichant clairement les intitulés de chaque niveau d'Impact (lignes) et de Probabilité (colonnes). 
- Garantir la cohérence entre la matrice affichée et les référentiels existants (`IMPACT_LEGEND` et `PROBABILITY_LEGEND`).
- Respecter la consigne de versioning en mettant à jour le numéro de version dans le footer et les références d'assets.

### Description
- Ajout de conteneurs DOM autour de la matrice consolidée : `simpleOverviewImpactLabels` et `simpleOverviewProbabilityLabels` dans `CartoModel.html` pour héberger les intitulés de niveaux.  
- Génération dynamique des titres de niveau dans `renderOverview()` de `assets/js/simple-mode.js` à partir de `IMPACT_LEGEND` et `PROBABILITY_LEGEND`, et raccordement DOM (`dom.overviewImpactLabels`, `dom.overviewProbabilityLabels`).
- Ajout de styles CSS (`.simple-overview-matrix-shell`, `.simple-overview-impact-labels`, `.simple-overview-probability-labels`, `.simple-overview-axis-level`) dans `assets/css/main.css` pour aligner les libellés avec la grille 4×4 et assurer un comportement responsive.
- Bump de version applicative et cache-busting à `2.1.29` (titre HTML, footer, et suffixes `?v=2.1.29` sur les scripts), et mise à jour de `DEFAULT_DATA.version` dans `assets/js/simple-mode.js`.

### Testing
- Exécution de `git diff --check` pour valider l'absence d'erreurs de diff, commande passée avec succès. 
- Vérification des occurrences de version via `rg -n "2\.1\.29|2\.1\.28" CartoModel.html assets/js/simple-mode.js` pour s'assurer que la version a été mise à jour, vérification réussie. 
- Vérification d'état et commit réalisé (`git status --short`, `git add` + `git commit`) confirmant les fichiers modifiés : `CartoModel.html`, `assets/js/simple-mode.js`, `assets/css/main.css`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ea0807f4832e8a2a0f2a082b8d0f)