### PR TITLE
Matrice simplifiée : mettre à jour libellés et passer en v2.1.30

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.29</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.29">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.30</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.30">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -314,11 +314,6 @@ Cadeau inapproprié à un agent public"></textarea>
                                     <div class="simple-overview-impact-labels" id="simpleOverviewImpactLabels"></div>
                                     <div class="matrix simple-overview-matrix-wrapper">
                                         <div class="matrix-grid simple-overview-matrix" id="simpleOverviewMatrix"></div>
-                                        <div class="axis-label x-axis">Probabilité →</div>
-                                        <div class="axis-label y-axis">
-                                            <span class="axis-text">Impact</span>
-                                            <span class="axis-arrow" aria-hidden="true">↑</span>
-                                        </div>
                                     </div>
                                 </div>
                                 <div class="simple-overview-probability-labels" id="simpleOverviewProbabilityLabels"></div>
@@ -710,7 +705,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.29</span>
+            <span class="app-version">Version 2.1.30</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.29',
+        version: '2.1.30',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -552,7 +552,7 @@
             impactLevels.forEach((impact) => {
                 const label = document.createElement('div');
                 label.className = 'simple-overview-axis-level y-level';
-                label.textContent = IMPACT_LEGEND[impact]?.title || `Impact ${impact}`;
+                label.textContent = ['Impact critique', 'Impact fort', 'Impact modéré', 'Impact faible'][4 - impact] || `Impact ${impact}`;
                 dom.overviewImpactLabels.appendChild(label);
             });
         }
@@ -561,7 +561,7 @@
             probabilityLevels.forEach((probability) => {
                 const label = document.createElement('div');
                 label.className = 'simple-overview-axis-level x-level';
-                label.textContent = PROBABILITY_LEGEND[probability]?.title || `Probabilité ${probability}`;
+                label.textContent = ['Peu probable', 'Moyennement probable', 'Probable', 'Très probable'][probability - 1] || `Probabilité ${probability}`;
                 dom.overviewProbabilityLabels.appendChild(label);
             });
         }


### PR DESCRIPTION
### Motivation
- Adapter la matrice consolidée de la "Version simplifiée" pour correspondre aux nouvelles exigences de libellés (retirer les axes explicites et utiliser des libellés textuels demandés). 
- Uniformiser les libellés des lignes et colonnes pour améliorer la lisibilité métier de la matrice consolidée. 
- Incrémenter le numéro de version de l’application et de la donnée simplifiée afin de refléter le changement et forcer le cache-busting CSS.

### Description
- Retire les éléments d’axes HTML visibles dans le bloc de la matrice consolidée de la version simplifiée en supprimant les balises d’axe `Probabilité →` et le bloc vertical `Impact` dans `CartoModel.html`.
- Remplace le rendu des libellés de lignes dans `assets/js/simple-mode.js` par `['Impact critique','Impact fort','Impact modéré','Impact faible']` (affichés de haut en bas). 
- Remplace le rendu des libellés de colonnes dans `assets/js/simple-mode.js` par `['Peu probable','Moyennement probable','Probable','Très probable']` (affichés de gauche à droite). 
- Bump de la version applicative / donnée à `2.1.30` dans `CartoModel.html` (titre, cache-busting CSS et footer) et dans `assets/js/simple-mode.js` (`DEFAULT_DATA.version`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check assets/js/simple-mode.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8eda54654832e869d9c8673ac8a84)