### PR TITLE
Aligner libellés de colonnes dans la vue consolidée (mode simplifié)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -316,7 +316,10 @@ Cadeau inapproprié à un agent public"></textarea>
                                         <div class="matrix-grid simple-overview-matrix" id="simpleOverviewMatrix"></div>
                                     </div>
                                 </div>
-                                <div class="simple-overview-probability-labels" id="simpleOverviewProbabilityLabels"></div>
+                                <div class="simple-overview-probability-row">
+                                    <div class="simple-overview-probability-spacer" aria-hidden="true"></div>
+                                    <div class="simple-overview-probability-labels" id="simpleOverviewProbabilityLabels"></div>
+                                </div>
                             </div>
                         </div>
                     </section>
@@ -705,7 +708,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.30</span>
+            <span class="app-version">Version 2.1.31</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2825,8 +2825,9 @@ tbody tr:hover {
 
 .simple-overview-matrix-shell {
     display: grid;
-    grid-template-columns: minmax(84px, auto) minmax(0, 1fr);
+    grid-template-columns: minmax(104px, max-content) minmax(300px, 520px);
     align-items: stretch;
+    justify-content: flex-start;
     gap: 10px;
 }
 
@@ -2837,9 +2838,19 @@ tbody tr:hover {
     padding: 2px 0;
 }
 
-.simple-overview-probability-labels {
+.simple-overview-probability-row {
     margin-top: 8px;
-    padding-left: 94px;
+    display: grid;
+    grid-template-columns: minmax(104px, max-content) minmax(300px, 520px);
+    justify-content: flex-start;
+    gap: 10px;
+}
+
+.simple-overview-probability-spacer {
+    min-height: 1px;
+}
+
+.simple-overview-probability-labels {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 2px;
@@ -2861,8 +2872,13 @@ tbody tr:hover {
 }
 
 .simple-overview-axis-level.x-level {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     text-align: center;
     padding: 0 4px;
+    white-space: pre-line;
+    min-height: 2.6em;
 }
 
 .simple-overview-matrix {
@@ -2918,8 +2934,9 @@ tbody tr:hover {
         gap: 8px;
     }
 
-    .simple-overview-probability-labels {
-        padding-left: 82px;
+    .simple-overview-probability-row {
+        grid-template-columns: 74px minmax(0, 1fr);
+        gap: 8px;
     }
 
     .simple-aggravating-list {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.30',
+        version: '2.1.31',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -561,7 +561,7 @@
             probabilityLevels.forEach((probability) => {
                 const label = document.createElement('div');
                 label.className = 'simple-overview-axis-level x-level';
-                label.textContent = ['Peu probable', 'Moyennement probable', 'Probable', 'Très probable'][probability - 1] || `Probabilité ${probability}`;
+                label.textContent = ['Peu probable', 'Moyennement\nprobable', 'Probable', 'Très\nprobable'][probability - 1] || `Probabilité ${probability}`;
                 dom.overviewProbabilityLabels.appendChild(label);
             });
         }


### PR DESCRIPTION
### Motivation
- Corriger le décalage entre les libellés de probabilité et les colonnes de la matrice consolidée en version simplifiée pour garantir que chaque libellé soit bien positionné face à sa colonne.
- Respecter l’exigence de mise à jour du numéro de version dans le footer pour cette tâche (incrément vers `2.1.31`).

### Description
- Ajout d’une ligne dédiée aux libellés de l’axe X avec un espaceur (`.simple-overview-probability-row` et `.simple-overview-probability-spacer`) dans `CartoModel.html` pour aligner visuellement les libellés et la grille de la matrice.
- Réorganisation de la grille CSS dans `assets/css/main.css` en harmonisant les `grid-template-columns` et en ajoutant `.simple-overview-probability-row` + règles pour garantir que la colonne d’étiquettes corresponde aux colonnes de la matrice et que l’axe X reste aligné sur différentes largeurs.
- Autorisation des retours à la ligne pour les libellés longs de l’axe X via `white-space: pre-line` et mise à jour des libellés injectés (`'Moyennement\nprobable'`, `'Très\nprobable'`) dans `assets/js/simple-mode.js` pour forcer l’affichage sur deux lignes si nécessaire.
- Mise à jour du numéro de version affiché dans le footer et de la version par défaut du mode simplifié à `2.1.31` dans `CartoModel.html` et `assets/js/simple-mode.js`.

### Testing
- Exécution de `node --check assets/js/simple-mode.js` réussie (pas d’erreurs de syntaxe). 
- Exécution de `git diff --check` réussie (aucun warning trouvé). 
- Les modifications ont été ajoutées et validées (`CartoModel.html`, `assets/css/main.css`, `assets/js/simple-mode.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f4a73f30832e86b7b40de581a1c4)