### PR TITLE
Retirer simpleRawLegendDetail dans la vue simplifiée et passer la version à 2.1.32

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -266,7 +266,6 @@ Cadeau inapproprié à un agent public"></textarea>
                                 <div class="matrix-description simple-matrix-description">
                                     <div class="matrix-description-header">Risque brut</div>
                                     <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
-                                    <div class="simple-legend-sub" id="simpleRawLegendDetail">Sélectionnez une case pour afficher la cotation détaillée.</div>
                                     <div class="simple-legend-description">
                                         <div class="simple-legend-block">
                                             <h4 id="simpleLegendProbabilityTitle">Probabilité 1 – Peu probable</h4>
@@ -708,7 +707,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.31</span>
+            <span class="app-version">Version 2.1.32</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.31',
+        version: '2.1.32',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -485,7 +485,6 @@
         if (!scenario) {
             if (dom.marker) dom.marker.classList.add('is-hidden');
             dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
-            dom.rawLegendDetail.textContent = 'Chargez des scénarios pour commencer la cotation.';
             renderLegendDescription(1, 1);
             dom.effectiveness.value = 0;
             dom.effectivenessLegend.textContent = '0% - Inefficace';
@@ -497,7 +496,6 @@
         if (dom.marker) dom.marker.classList.remove('is-hidden');
         const score = prob * impact;
         dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
-        dom.rawLegendDetail.textContent = `Probabilité: ${prob}/4 • Impact: ${impact}/4`;
         renderLegendDescription(prob, impact);
         dom.matrix.querySelectorAll('.simple-matrix-cell').forEach((cell) => {
             const isActive = Number(cell.dataset.prob) === prob && Number(cell.dataset.impact) === impact;
@@ -864,7 +862,6 @@
         dom.matrix = document.getElementById('simpleMatrix');
         dom.matrixWrapper = document.querySelector('.simple-edit-matrix');
         dom.rawLegend = document.getElementById('simpleRawLegend');
-        dom.rawLegendDetail = document.getElementById('simpleRawLegendDetail');
         dom.legendProbabilityTitle = document.getElementById('simpleLegendProbabilityTitle');
         dom.legendProbabilityDetail1 = document.getElementById('simpleLegendProbabilityDetail1');
         dom.legendProbabilityDetail2 = document.getElementById('simpleLegendProbabilityDetail2');


### PR DESCRIPTION
### Motivation
- Supprimer le sous-texte d’aide redondant dans le bloc « Risque brut » de la vue simplifiée et garder le code cohérent en supprimant les références JS associées.

### Description
- Retire l'élément HTML avec l'id `simpleRawLegendDetail` du bloc *Risque brut* dans `CartoModel.html`.
- Supprime les mises à jour de texte et l'initialisation DOM liées à `dom.rawLegendDetail` dans `assets/js/simple-mode.js` afin d'éviter les références nulles.
- Met à jour la version affichée et la version par défaut des données simplifiées à `2.1.32` dans le footer et dans `DEFAULT_DATA.version`.

### Testing
- `node -c assets/js/simple-mode.js` a été exécuté pour vérifier la validité syntaxique du fichier JavaScript et a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8f7c7da60832eaf3cd2301803f2ae)