### PR TITLE
Ajouter bouton de suppression dans la cotation simplifiée et mettre la version à 2.1.33

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -248,7 +248,10 @@ Cadeau inapproprié à un agent public"></textarea>
                                 <div class="simple-caption">Scénario sélectionné</div>
                                 <h3 id="simpleCurrentScenario" class="simple-current-scenario">Aucun scénario sélectionné</h3>
                             </div>
-                            <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
+                            <div class="simple-sticky-actions">
+                                <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
+                                <button class="btn btn-secondary simple-delete-btn" id="simpleDeleteBtn" aria-label="Supprimer le scénario sélectionné" title="Supprimer ce scénario">🗑️ Supprimer ce scénario</button>
+                            </div>
                         </div>
 
                         <div class="risk-matrix-editor simple-risk-matrix-editor">
@@ -707,7 +710,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.32</span>
+            <span class="app-version">Version 2.1.33</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2520,6 +2520,24 @@ tbody tr:hover {
     gap: 12px;
 }
 
+.simple-sticky-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: stretch;
+}
+
+.simple-delete-btn {
+    color: #b42318;
+    border-color: #f1b5af;
+    background: #fff1f0;
+}
+
+.simple-delete-btn:hover {
+    background: #ffe2df;
+    border-color: #e88780;
+}
+
 .simple-caption {
     font-size: 0.82em;
     text-transform: uppercase;

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.32',
+        version: '2.1.33',
         scenarios: [],
         selectedId: null,
         updatedAt: null
@@ -261,6 +261,12 @@
         saveLocal();
     }
 
+    function deleteCurrentScenario() {
+        const current = getSelectedScenario();
+        if (!current) return;
+        deleteScenario(current.id);
+    }
+
     function deleteScenario(id) {
         const index = state.data.scenarios.findIndex((scenario) => scenario.id === id);
         if (index === -1) return;
@@ -476,6 +482,7 @@
 
         dom.currentScenario.textContent = scenario ? scenario.text : 'Aucun scénario sélectionné';
         dom.duplicateBtn.disabled = disabled;
+        dom.deleteBtn.disabled = disabled;
         dom.prevBtn.disabled = disabled;
         dom.nextBtn.disabled = disabled;
         dom.effectiveness.disabled = disabled;
@@ -805,6 +812,7 @@
 
         dom.loadScenariosBtn.addEventListener('click', () => replaceScenariosFromText(dom.scenariosInput.value));
         dom.duplicateBtn.addEventListener('click', duplicateScenario);
+        dom.deleteBtn.addEventListener('click', deleteCurrentScenario);
         dom.prevBtn.addEventListener('click', () => goToScenario(-1));
         dom.nextBtn.addEventListener('click', () => goToScenario(1));
 
@@ -859,6 +867,7 @@
         dom.overviewPanel = document.getElementById('simple-overview-panel');
         dom.currentScenario = document.getElementById('simpleCurrentScenario');
         dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
+        dom.deleteBtn = document.getElementById('simpleDeleteBtn');
         dom.matrix = document.getElementById('simpleMatrix');
         dom.matrixWrapper = document.querySelector('.simple-edit-matrix');
         dom.rawLegend = document.getElementById('simpleRawLegend');


### PR DESCRIPTION
### Motivation
- Permettre la suppression rapide du scénario actuellement sélectionné depuis l'onglet `Version simplifiée > Cotation` en ajoutant un bouton de type poubelle sous le bouton de duplication.
- Respecter la demande de mise à jour du numéro de version affiché dans le footer pour chaque tâche.

### Description
- Ajout du bouton `🗑️ Supprimer ce scénario` dans le header de l'onglet cotation et regroupement des actions dans une nouvelle classe HTML `simple-sticky-actions` (`CartoModel.html`).
- Implémentation de la fonction `deleteCurrentScenario()` et branchement du nouvel élément DOM `dom.deleteBtn` pour appeler `deleteScenario(id)`, ainsi que gestion de l'état `disabled` (`assets/js/simple-mode.js`).
- Ajout des styles pour empiler les actions et styliser le bouton supprimer via `.simple-sticky-actions` et `.simple-delete-btn` (`assets/css/main.css`).
- Incrément de la version affichée et du `DEFAULT_DATA.version` de la version `2.1.32` à `2.1.33` (`CartoModel.html` et `assets/js/simple-mode.js`).

### Testing
- Exécution de la vérification de syntaxe JS avec `node --check assets/js/simple-mode.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fd2b116c832ea974fc613f9200d1)