### PR TITLE
Simple mode: EN/FR toggle, hidden probability details, discreet progress bar, bump to 2.1.34

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.30</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.30">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.34</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.34">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -213,8 +213,9 @@
         <div id="simple-tab" class="tab-content">
             <div class="main-content simple-mode">
                 <div class="toolbar">
-                    <div class="toolbar-title">Version simplifiée - Cotation des risques bruts</div>
+                    <div class="toolbar-title" id="simpleToolbarTitle">Version simplifiée - Cotation des risques bruts</div>
                     <div class="toolbar-actions">
+                        <button class="btn btn-outline simple-lang-toggle" id="simpleLanguageToggleBtn" aria-label="Basculer la langue de la version simplifiée">EN</button>
                         <button class="btn btn-outline" id="simpleExportBtn">📤 Export JSON</button>
                         <button class="btn btn-outline" id="simpleExportCsvBtn">📄 Export CSV</button>
                         <button class="btn btn-secondary" id="simpleImportBtn">📥 Import JSON</button>
@@ -224,20 +225,20 @@
 
                 <div class="content-area simple-mode-content">
                     <div class="simple-subtabs">
-                        <button class="simple-subtab active" data-simple-view="scenarios">1. Chargement des scénarios</button>
-                        <button class="simple-subtab" data-simple-view="assessment">2. Cotation</button>
-                        <button class="simple-subtab" data-simple-view="overview">3. Vue consolidée</button>
+                        <button class="simple-subtab active" id="simpleSubtabScenarios" data-simple-view="scenarios">1. Chargement des scénarios</button>
+                        <button class="simple-subtab" id="simpleSubtabAssessment" data-simple-view="assessment">2. Cotation</button>
+                        <button class="simple-subtab" id="simpleSubtabOverview" data-simple-view="overview">3. Vue consolidée</button>
                     </div>
 
                     <section class="simple-panel active" id="simple-scenarios-panel">
-                        <label class="form-label" for="simpleScenariosInput">Collez vos scénarios (1 ligne = 1 scénario, max. 500 caractères)</label>
+                        <label class="form-label" id="simpleScenariosLabel" for="simpleScenariosInput">Collez vos scénarios (1 ligne = 1 scénario, max. 500 caractères)</label>
                         <textarea id="simpleScenariosInput" class="form-input simple-textarea" rows="7" placeholder="Exemple :
 Paiement indu via intermédiaire
 Conflit d'intérêt dans la sélection fournisseur
 Cadeau inapproprié à un agent public"></textarea>
                         <div class="simple-actions-row">
                             <button class="btn btn-primary" id="simpleLoadScenariosBtn">Charger les scénarios</button>
-                            <span class="simple-helper">Les scénarios remplacent la liste actuelle.</span>
+                            <span class="simple-helper" id="simpleScenariosHelper">Les scénarios remplacent la liste actuelle.</span>
                         </div>
                         <div id="simpleScenarioList" class="simple-scenario-list"></div>
                     </section>
@@ -245,13 +246,16 @@ Cadeau inapproprié à un agent public"></textarea>
                     <section class="simple-panel" id="simple-assessment-panel">
                         <div class="simple-sticky-header">
                             <div>
-                                <div class="simple-caption">Scénario sélectionné</div>
+                                <div class="simple-caption" id="simpleSelectedCaption">Scénario sélectionné</div>
                                 <h3 id="simpleCurrentScenario" class="simple-current-scenario">Aucun scénario sélectionné</h3>
                             </div>
                             <div class="simple-sticky-actions">
                                 <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
                                 <button class="btn btn-secondary simple-delete-btn" id="simpleDeleteBtn" aria-label="Supprimer le scénario sélectionné" title="Supprimer ce scénario">🗑️ Supprimer ce scénario</button>
                             </div>
+                        </div>
+                        <div class="simple-assessment-progress" id="simpleAssessmentProgress" aria-hidden="true">
+                            <span id="simpleAssessmentProgressFill" class="simple-assessment-progress-fill"></span>
                         </div>
 
                         <div class="risk-matrix-editor simple-risk-matrix-editor">
@@ -267,34 +271,39 @@ Cadeau inapproprié à un agent public"></textarea>
                                     </div>
                                 </div>
                                 <div class="matrix-description simple-matrix-description">
-                                    <div class="matrix-description-header">Risque brut</div>
+                                    <div class="matrix-description-header" id="simpleRawRiskTitle">Risque brut</div>
                                     <div id="simpleRawLegend" class="simple-legend-main">P1 × I1 = 1 (Faible)</div>
                                     <div class="simple-legend-description">
                                         <div class="simple-legend-block">
-                                            <h4 id="simpleLegendProbabilityTitle">Probabilité 1 – Peu probable</h4>
-                                            <p id="simpleLegendProbabilityDetail1">Événement non survenu sur les 5 dernières années.</p>
-                                            <p id="simpleLegendProbabilityDetail2">Événement non attendu sur les 5 prochaines années.</p>
+                                            <div class="simple-legend-title-row">
+                                                <h4 id="simpleLegendProbabilityTitle">Probabilité 1 – Peu probable</h4>
+                                                <button type="button" id="simpleLegendToggleBtn" class="simple-legend-toggle-btn" aria-expanded="false" aria-controls="simpleLegendProbabilityDetails" title="Afficher/masquer le détail de probabilité">ⓘ</button>
+                                            </div>
+                                            <div id="simpleLegendProbabilityDetails" class="simple-legend-probability-details">
+                                                <p id="simpleLegendProbabilityDetail1">Événement non survenu sur les 5 dernières années.</p>
+                                                <p id="simpleLegendProbabilityDetail2">Événement non attendu sur les 5 prochaines années.</p>
+                                            </div>
                                         </div>
                                         <div class="simple-legend-block">
                                             <h4 id="simpleLegendImpactTitle">Impact 1 – Faible</h4>
                                             <ul id="simpleLegendImpactBullets" class="simple-legend-bullets"></ul>
                                         </div>
                                         <div class="simple-aggravating-factors">
-                                            <h4>Facteurs aggravants</h4>
+                                            <h4 id="simpleAggravatingTitle">Facteurs aggravants</h4>
                                             <div id="simpleAggravatingFactors" class="simple-aggravating-list"></div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                             <div class="simple-effectiveness-block">
-                                <label class="form-label" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
+                                <label class="form-label" id="simpleEffectivenessLabel" for="simpleEffectiveness">Efficacité des mesures de maîtrise</label>
                                 <input type="range" id="simpleEffectiveness" min="0" max="100" step="5" value="0">
                                 <div id="simpleEffectivenessLegend" class="simple-legend-sub">0% - Inefficace</div>
                             </div>
                         </div>
 
                         <div class="simple-comment-card">
-                            <label class="form-label" for="simpleComment">Commentaires</label>
+                            <label class="form-label" id="simpleCommentLabel" for="simpleComment">Commentaires</label>
                             <textarea id="simpleComment" class="form-input simple-textarea" rows="4" placeholder="Ajoutez vos observations..."></textarea>
                         </div>
 
@@ -710,7 +719,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.33</span>
+            <span class="app-version">Version 2.1.34</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2426,6 +2426,11 @@ tbody tr:hover {
     color: #fff;
 }
 
+.simple-lang-toggle {
+    min-width: 52px;
+    letter-spacing: 0.04em;
+}
+
 .simple-panel {
     display: none;
 }
@@ -2518,6 +2523,23 @@ tbody tr:hover {
     justify-content: space-between;
     align-items: center;
     gap: 12px;
+}
+
+.simple-assessment-progress {
+    width: 100%;
+    height: 2px;
+    margin: -8px 0 10px;
+    background: rgba(148, 163, 184, 0.14);
+    border-radius: 99px;
+    overflow: hidden;
+}
+
+.simple-assessment-progress-fill {
+    display: block;
+    width: 0;
+    height: 100%;
+    background: rgba(51, 65, 85, 0.25);
+    transition: width 0.22s ease;
 }
 
 .simple-sticky-actions {
@@ -2752,6 +2774,39 @@ tbody tr:hover {
     margin: 0 0 10px;
     color: #27313d;
     font-size: 1.1rem;
+}
+
+.simple-legend-title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.simple-legend-toggle-btn {
+    border: 1px solid #dbe2ea;
+    background: #ffffff;
+    color: #8a97a6;
+    border-radius: 999px;
+    width: 20px;
+    height: 20px;
+    font-size: 0.74rem;
+    line-height: 1;
+    padding: 0;
+    cursor: pointer;
+    opacity: 0.6;
+}
+
+.simple-legend-toggle-btn:hover {
+    opacity: 1;
+}
+
+.simple-legend-probability-details {
+    display: none;
+}
+
+.simple-legend-probability-details.visible {
+    display: block;
 }
 
 .simple-legend-block p {

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,10 +1,11 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.33',
+        version: '2.1.34',
         scenarios: [],
         selectedId: null,
-        updatedAt: null
+        updatedAt: null,
+        language: 'fr'
     };
     const DEFAULT_AGGRAVATING_FACTORS = [
         { id: 'Pays à risque de corruption élevé (CPI < 40)', label: 'Pays à risque de corruption élevé (CPI < 40)' },
@@ -62,7 +63,69 @@
     const state = {
         data: cloneData(DEFAULT_DATA),
         view: 'scenarios',
-        highlightedScenarioId: null
+        highlightedScenarioId: null,
+        showProbabilityLegendDetails: false
+    };
+
+    const UI_TRANSLATIONS = {
+        fr: {
+            legendToggleTitle: 'Afficher/masquer le détail de probabilité',
+            noScenarioSelected: 'Aucun scénario sélectionné',
+            toolbarTitle: 'Version simplifiée - Cotation des risques bruts',
+            subtabScenarios: '1. Chargement des scénarios',
+            subtabAssessment: '2. Cotation',
+            subtabOverview: '3. Vue consolidée',
+            scenariosLabel: 'Collez vos scénarios (1 ligne = 1 scénario, max. 500 caractères)',
+            scenariosPlaceholder: `Exemple :
+Paiement indu via intermédiaire
+Conflit d'intérêt dans la sélection fournisseur
+Cadeau inapproprié à un agent public`,
+            loadScenarios: 'Charger les scénarios',
+            scenariosHelper: 'Les scénarios remplacent la liste actuelle.',
+            selectedScenarioCaption: 'Scénario sélectionné',
+            duplicateScenario: 'Dupliquer ce scénario',
+            deleteScenarioLabel: 'Supprimer ce scénario',
+            rawRiskTitle: 'Risque brut',
+            aggravatingTitle: 'Facteurs aggravants',
+            effectivenessLabel: 'Efficacité des mesures de maîtrise',
+            commentsLabel: 'Commentaires',
+            commentsPlaceholder: 'Ajoutez vos observations...',
+            prevScenario: '← Scénario précédent',
+            nextScenario: 'Scénario suivant →',
+            weak: 'Faible',
+            moderate: 'Modéré',
+            high: 'Élevé',
+            critical: 'Critique'
+        },
+        en: {
+            legendToggleTitle: 'Show/hide probability details',
+            noScenarioSelected: 'No scenario selected',
+            toolbarTitle: 'Simplified version - Raw risk scoring',
+            subtabScenarios: '1. Scenario loading',
+            subtabAssessment: '2. Scoring',
+            subtabOverview: '3. Consolidated view',
+            scenariosLabel: 'Paste your scenarios (1 line = 1 scenario, max 500 characters)',
+            scenariosPlaceholder: `Example:
+Undue payment through intermediary
+Conflict of interest in supplier selection
+Inappropriate gift to a public official`,
+            loadScenarios: 'Load scenarios',
+            scenariosHelper: 'Loading replaces the current list.',
+            selectedScenarioCaption: 'Selected scenario',
+            duplicateScenario: 'Duplicate this scenario',
+            deleteScenarioLabel: 'Delete this scenario',
+            rawRiskTitle: 'Raw risk',
+            aggravatingTitle: 'Aggravating factors',
+            effectivenessLabel: 'Control effectiveness',
+            commentsLabel: 'Comments',
+            commentsPlaceholder: 'Add your observations...',
+            prevScenario: '← Previous scenario',
+            nextScenario: 'Next scenario →',
+            weak: 'Low',
+            moderate: 'Medium',
+            high: 'High',
+            critical: 'Critical'
+        }
     };
 
     const dom = {};
@@ -327,10 +390,11 @@
     }
 
     function scoreLabel(score) {
-        if (score >= 20) return 'Critique';
-        if (score >= 12) return 'Élevé';
-        if (score >= 6) return 'Modéré';
-        return 'Faible';
+        const locale = UI_TRANSLATIONS[state.data.language] || UI_TRANSLATIONS.fr;
+        if (score >= 20) return locale.critical;
+        if (score >= 12) return locale.high;
+        if (score >= 6) return locale.moderate;
+        return locale.weak;
     }
 
     function effectivenessLabel(value) {
@@ -479,8 +543,9 @@
     function renderAssessment() {
         const scenario = getSelectedScenario();
         const disabled = !scenario;
+        const locale = UI_TRANSLATIONS[state.data.language] || UI_TRANSLATIONS.fr;
 
-        dom.currentScenario.textContent = scenario ? scenario.text : 'Aucun scénario sélectionné';
+        dom.currentScenario.textContent = scenario ? scenario.text : locale.noScenarioSelected;
         dom.duplicateBtn.disabled = disabled;
         dom.deleteBtn.disabled = disabled;
         dom.prevBtn.disabled = disabled;
@@ -491,11 +556,12 @@
 
         if (!scenario) {
             if (dom.marker) dom.marker.classList.add('is-hidden');
-            dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
+            dom.rawLegend.textContent = `P1 × I1 = 1 (${locale.weak})`;
             renderLegendDescription(1, 1);
             dom.effectiveness.value = 0;
             dom.effectivenessLegend.textContent = '0% - Inefficace';
             dom.comment.value = '';
+            renderAssessmentProgress();
             return;
         }
 
@@ -521,6 +587,19 @@
         const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
         dom.prevBtn.disabled = idx <= 0;
         dom.nextBtn.disabled = idx >= state.data.scenarios.length - 1;
+        renderAssessmentProgress();
+    }
+
+    function renderAssessmentProgress() {
+        if (!dom.assessmentProgressFill) return;
+        const total = state.data.scenarios.length;
+        if (!total || !state.data.selectedId) {
+            dom.assessmentProgressFill.style.width = '0%';
+            return;
+        }
+        const index = state.data.scenarios.findIndex((scenario) => scenario.id === state.data.selectedId);
+        const ratio = index < 0 ? 0 : ((index + 1) / total) * 100;
+        dom.assessmentProgressFill.style.width = `${Math.max(0, Math.min(100, ratio)).toFixed(2)}%`;
     }
 
     function setHighlightedScenario(id, options = {}) {
@@ -684,6 +763,55 @@
         }
     }
 
+    function applyLanguage(language) {
+        const nextLanguage = language === 'en' ? 'en' : 'fr';
+        const locale = UI_TRANSLATIONS[nextLanguage] || UI_TRANSLATIONS.fr;
+        state.data.language = nextLanguage;
+        if (!dom.languageToggleBtn) return;
+        dom.languageToggleBtn.textContent = nextLanguage === 'fr' ? 'EN' : 'FR';
+        dom.languageToggleBtn.title = nextLanguage === 'fr' ? 'Switch simplified mode to English' : 'Passer la version simplifiée en français';
+        dom.legendToggleBtn.title = locale.legendToggleTitle;
+        if (dom.toolbarTitle) dom.toolbarTitle.textContent = locale.toolbarTitle;
+        if (dom.subtabScenarios) dom.subtabScenarios.textContent = locale.subtabScenarios;
+        if (dom.subtabAssessment) dom.subtabAssessment.textContent = locale.subtabAssessment;
+        if (dom.subtabOverview) dom.subtabOverview.textContent = locale.subtabOverview;
+        if (dom.scenariosLabel) dom.scenariosLabel.textContent = locale.scenariosLabel;
+        if (dom.scenariosInput) dom.scenariosInput.placeholder = locale.scenariosPlaceholder;
+        if (dom.loadScenariosBtn) dom.loadScenariosBtn.textContent = locale.loadScenarios;
+        if (dom.scenariosHelper) dom.scenariosHelper.textContent = locale.scenariosHelper;
+        if (dom.selectedCaption) dom.selectedCaption.textContent = locale.selectedScenarioCaption;
+        if (dom.duplicateBtn) dom.duplicateBtn.textContent = locale.duplicateScenario;
+        if (dom.deleteBtn) {
+            dom.deleteBtn.textContent = `🗑️ ${locale.deleteScenarioLabel}`;
+            dom.deleteBtn.title = locale.deleteScenarioLabel;
+            dom.deleteBtn.setAttribute('aria-label', locale.deleteScenarioLabel);
+        }
+        if (dom.rawRiskTitle) dom.rawRiskTitle.textContent = locale.rawRiskTitle;
+        if (dom.aggravatingTitle) dom.aggravatingTitle.textContent = locale.aggravatingTitle;
+        if (dom.effectivenessLabel) dom.effectivenessLabel.textContent = locale.effectivenessLabel;
+        if (dom.commentLabel) dom.commentLabel.textContent = locale.commentsLabel;
+        if (dom.comment) dom.comment.placeholder = locale.commentsPlaceholder;
+        if (dom.prevBtn) dom.prevBtn.textContent = locale.prevScenario;
+        if (dom.nextBtn) dom.nextBtn.textContent = locale.nextScenario;
+    }
+
+    function toggleLanguage() {
+        applyLanguage(state.data.language === 'fr' ? 'en' : 'fr');
+        render();
+        saveLocal();
+    }
+
+    function setProbabilityLegendDetailsVisible(visible) {
+        state.showProbabilityLegendDetails = Boolean(visible);
+        if (!dom.legendProbabilityDetails || !dom.legendToggleBtn) return;
+        dom.legendProbabilityDetails.classList.toggle('visible', state.showProbabilityLegendDetails);
+        dom.legendToggleBtn.setAttribute('aria-expanded', String(state.showProbabilityLegendDetails));
+    }
+
+    function toggleProbabilityLegendDetails() {
+        setProbabilityLegendDetailsVisible(!state.showProbabilityLegendDetails);
+    }
+
     function syncSimpleMatrixSquare() {
         if (!dom.matrixWrapper) return;
         const width = dom.matrixWrapper.getBoundingClientRect().width;
@@ -781,6 +909,7 @@
                 }
                 state.data = cloneData(DEFAULT_DATA);
                 state.data.version = parsed.version || DEFAULT_DATA.version;
+                state.data.language = parsed.language === 'en' ? 'en' : 'fr';
                 state.data.scenarios = parsed.scenarios.map((s) => ({
                     id: s.id || uid(),
                     text: normalizeScenarioText(s.text),
@@ -829,6 +958,8 @@
         dom.exportBtn.addEventListener('click', exportData);
         dom.exportCsvBtn.addEventListener('click', exportCsvData);
         dom.importBtn.addEventListener('click', () => dom.importFile.click());
+        dom.languageToggleBtn.addEventListener('click', toggleLanguage);
+        dom.legendToggleBtn.addEventListener('click', toggleProbabilityLegendDetails);
         dom.importFile.addEventListener('change', (evt) => {
             importDataFromFile(evt.target.files[0]);
             evt.target.value = '';
@@ -861,34 +992,49 @@
     function init() {
         dom.scenariosInput = document.getElementById('simpleScenariosInput');
         dom.loadScenariosBtn = document.getElementById('simpleLoadScenariosBtn');
+        dom.toolbarTitle = document.getElementById('simpleToolbarTitle');
+        dom.subtabScenarios = document.getElementById('simpleSubtabScenarios');
+        dom.subtabAssessment = document.getElementById('simpleSubtabAssessment');
+        dom.subtabOverview = document.getElementById('simpleSubtabOverview');
+        dom.scenariosLabel = document.getElementById('simpleScenariosLabel');
+        dom.scenariosHelper = document.getElementById('simpleScenariosHelper');
         dom.scenarioList = document.getElementById('simpleScenarioList');
         dom.scenariosPanel = document.getElementById('simple-scenarios-panel');
         dom.assessmentPanel = document.getElementById('simple-assessment-panel');
         dom.overviewPanel = document.getElementById('simple-overview-panel');
         dom.currentScenario = document.getElementById('simpleCurrentScenario');
+        dom.selectedCaption = document.getElementById('simpleSelectedCaption');
         dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
         dom.deleteBtn = document.getElementById('simpleDeleteBtn');
         dom.matrix = document.getElementById('simpleMatrix');
         dom.matrixWrapper = document.querySelector('.simple-edit-matrix');
         dom.rawLegend = document.getElementById('simpleRawLegend');
+        dom.rawRiskTitle = document.getElementById('simpleRawRiskTitle');
         dom.legendProbabilityTitle = document.getElementById('simpleLegendProbabilityTitle');
         dom.legendProbabilityDetail1 = document.getElementById('simpleLegendProbabilityDetail1');
         dom.legendProbabilityDetail2 = document.getElementById('simpleLegendProbabilityDetail2');
         dom.legendImpactTitle = document.getElementById('simpleLegendImpactTitle');
         dom.legendImpactBullets = document.getElementById('simpleLegendImpactBullets');
         dom.aggravatingFactorsList = document.getElementById('simpleAggravatingFactors');
+        dom.aggravatingTitle = document.getElementById('simpleAggravatingTitle');
         dom.effectiveness = document.getElementById('simpleEffectiveness');
+        dom.effectivenessLabel = document.getElementById('simpleEffectivenessLabel');
         dom.effectiveness.min = String(EFFECTIVENESS_LEVELS[0].value);
         dom.effectiveness.max = String(EFFECTIVENESS_LEVELS[EFFECTIVENESS_LEVELS.length - 1].value);
         dom.effectiveness.step = '1';
         dom.effectivenessLegend = document.getElementById('simpleEffectivenessLegend');
         dom.comment = document.getElementById('simpleComment');
+        dom.commentLabel = document.getElementById('simpleCommentLabel');
         dom.prevBtn = document.getElementById('simplePrevBtn');
         dom.nextBtn = document.getElementById('simpleNextBtn');
         dom.exportBtn = document.getElementById('simpleExportBtn');
         dom.exportCsvBtn = document.getElementById('simpleExportCsvBtn');
         dom.importBtn = document.getElementById('simpleImportBtn');
         dom.importFile = document.getElementById('simpleImportFile');
+        dom.languageToggleBtn = document.getElementById('simpleLanguageToggleBtn');
+        dom.legendToggleBtn = document.getElementById('simpleLegendToggleBtn');
+        dom.legendProbabilityDetails = document.getElementById('simpleLegendProbabilityDetails');
+        dom.assessmentProgressFill = document.getElementById('simpleAssessmentProgressFill');
         dom.overviewRiskList = document.getElementById('simpleOverviewRiskList');
         dom.overviewMatrix = document.getElementById('simpleOverviewMatrix');
         dom.overviewImpactLabels = document.getElementById('simpleOverviewImpactLabels');
@@ -901,6 +1047,8 @@
         loadLocal();
         ensureSelectedScenario();
         state.highlightedScenarioId = state.data.selectedId;
+        applyLanguage(state.data.language);
+        setProbabilityLegendDetailsVisible(false);
 
         renderMatrix();
         syncSimpleMatrixSquare();


### PR DESCRIPTION
### Motivation
- Répondre aux besoins de la "version simplifiée": pouvoir basculer l’interface en anglais, masquer par défaut le texte détaillé des niveaux de probabilité et afficher une barre de progression très discrète dans l’onglet « Cotation ». 
- Mettre à jour le numéro de version visible dans le footer et les métadonnées de la version simplifiée.

### Description
- Ajout d’un bouton discret `EN/FR` dans la barre d’actions de la version simplifiée et implémentation d’une localisation UI FR/EN pour les principaux libellés (toolbar, sous-onglets, boutons, labels, placeholders) dans `assets/js/simple-mode.js` (nouveaux `UI_TRANSLATIONS`, `applyLanguage`, `toggleLanguage`, utilisation des libellés lors du rendu).
- Masquage par défaut du détail textuel de la probabilité et ajout d’un petit bouton d’info `ⓘ` pour afficher/masquer ce détail; DOM + CSS: `CartoModel.html` (nouveau bouton et conteneur `#simpleLegendProbabilityDetails`) et `assets/css/main.css` (styles `.simple-legend-probability-details`, `.simple-legend-toggle-btn`).
- Ajout d’une barre d’avancement très fine et discrète dans l’onglet « Cotation » (HTML `#simpleAssessmentProgress` / `#simpleAssessmentProgressFill` + CSS `.simple-assessment-progress` / `.simple-assessment-progress-fill`) et mise à jour automatique via `renderAssessmentProgress()` en JS.
- Divers ajustements DOM/ids pour piloter la localisation et l’UX (nouveaux ids: `simpleLanguageToggleBtn`, `simpleLegendToggleBtn`, `simpleToolbarTitle`, `simpleSubtab*`, `simpleScenariosLabel`, etc.) et prise en compte de la langue lors de l’import JSON (`language` dans les données simplifiées).
- Incrément du numéro de version à 2.1.34 dans `CartoModel.html` (titre, querystring CSS, footer) et dans `DEFAULT_DATA.version` de `assets/js/simple-mode.js`.

### Testing
- Exécution automatique: `node --check assets/js/simple-mode.js` — OK (pas d’erreur de syntaxe).
- Aucune suite de tests UI automatisée disponible ici; validation visuelle (navigateur) non effectuée automatiquement dans cet environnement.

Version mise à jour: 2.1.34

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbd9e1170832eb1b0ac3850c72e1c)