### PR TITLE
Localize simplified-mode EN labels and bump version to 2.1.36

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.35</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.35">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.36</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.36">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -263,9 +263,9 @@ Cadeau inapproprié à un agent public"></textarea>
                                 <div class="edit-matrix-container">
                                     <div class="matrix edit-matrix simple-edit-matrix">
                                         <div class="matrix-grid" id="simpleMatrix"></div>
-                                        <div class="axis-label x-axis">Probabilité →</div>
+                                        <div class="axis-label x-axis" id="simpleMatrixProbabilityAxis">Probabilité →</div>
                                         <div class="axis-label y-axis">
-                                            <span class="axis-text">Impact</span>
+                                            <span class="axis-text" id="simpleMatrixImpactAxis">Impact</span>
                                             <span class="axis-arrow" aria-hidden="true">↑</span>
                                         </div>
                                     </div>
@@ -316,11 +316,11 @@ Cadeau inapproprié à un agent public"></textarea>
                     <section class="simple-panel" id="simple-overview-panel">
                         <div class="simple-overview-layout">
                             <div class="simple-overview-list-card">
-                                <h3>Risques bruts triés (P × I décroissant)</h3>
+                                <h3 id="simpleOverviewSortedTitle">Risques bruts triés (P × I décroissant)</h3>
                                 <div id="simpleOverviewRiskList" class="simple-overview-risk-list"></div>
                             </div>
                             <div class="simple-overview-matrix-card">
-                                <h3>Matrice des risques bruts</h3>
+                                <h3 id="simpleOverviewMatrixTitle">Matrice des risques bruts</h3>
                                 <div class="simple-overview-matrix-shell">
                                     <div class="simple-overview-impact-labels" id="simpleOverviewImpactLabels"></div>
                                     <div class="matrix simple-overview-matrix-wrapper">
@@ -719,7 +719,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.35</span>
+            <span class="app-version">Version 2.1.36</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.35',
+        version: '2.1.36',
         scenarios: [],
         selectedId: null,
         updatedAt: null,
@@ -144,7 +144,11 @@ Cadeau inapproprié à un agent public`,
             weak: 'Faible',
             moderate: 'Modéré',
             high: 'Élevé',
-            critical: 'Critique'
+            critical: 'Critique',
+            matrixProbabilityAxis: 'Probabilité →',
+            matrixImpactAxis: 'Impact',
+            overviewSortedTitle: 'Risques bruts triés (P × I décroissant)',
+            overviewMatrixTitle: 'Matrice des risques bruts'
         },
         en: {
             legendToggleTitle: 'Show/hide probability details',
@@ -173,7 +177,11 @@ Inappropriate gift to a public official`,
             weak: 'Low',
             moderate: 'Medium',
             high: 'High',
-            critical: 'Critical'
+            critical: 'Critical',
+            matrixProbabilityAxis: 'Probability →',
+            matrixImpactAxis: 'Impact',
+            overviewSortedTitle: 'Raw risks sorted (P × I descending)',
+            overviewMatrixTitle: 'Raw risk matrix'
         }
     };
 
@@ -852,6 +860,10 @@ Inappropriate gift to a public official`,
         if (dom.comment) dom.comment.placeholder = locale.commentsPlaceholder;
         if (dom.prevBtn) dom.prevBtn.textContent = locale.prevScenario;
         if (dom.nextBtn) dom.nextBtn.textContent = locale.nextScenario;
+        if (dom.matrixProbabilityAxis) dom.matrixProbabilityAxis.textContent = locale.matrixProbabilityAxis;
+        if (dom.matrixImpactAxis) dom.matrixImpactAxis.textContent = locale.matrixImpactAxis;
+        if (dom.overviewSortedTitle) dom.overviewSortedTitle.textContent = locale.overviewSortedTitle;
+        if (dom.overviewMatrixTitle) dom.overviewMatrixTitle.textContent = locale.overviewMatrixTitle;
     }
 
     function toggleLanguage() {
@@ -1066,6 +1078,8 @@ Inappropriate gift to a public official`,
         dom.duplicateBtn = document.getElementById('simpleDuplicateBtn');
         dom.deleteBtn = document.getElementById('simpleDeleteBtn');
         dom.matrix = document.getElementById('simpleMatrix');
+        dom.matrixProbabilityAxis = document.getElementById('simpleMatrixProbabilityAxis');
+        dom.matrixImpactAxis = document.getElementById('simpleMatrixImpactAxis');
         dom.matrixWrapper = document.querySelector('.simple-edit-matrix');
         dom.rawLegend = document.getElementById('simpleRawLegend');
         dom.rawRiskTitle = document.getElementById('simpleRawRiskTitle');
@@ -1095,6 +1109,8 @@ Inappropriate gift to a public official`,
         dom.legendProbabilityDetails = document.getElementById('simpleLegendProbabilityDetails');
         dom.assessmentProgressFill = document.getElementById('simpleAssessmentProgressFill');
         dom.overviewRiskList = document.getElementById('simpleOverviewRiskList');
+        dom.overviewSortedTitle = document.getElementById('simpleOverviewSortedTitle');
+        dom.overviewMatrixTitle = document.getElementById('simpleOverviewMatrixTitle');
         dom.overviewMatrix = document.getElementById('simpleOverviewMatrix');
         dom.overviewImpactLabels = document.getElementById('simpleOverviewImpactLabels');
         dom.overviewProbabilityLabels = document.getElementById('simpleOverviewProbabilityLabels');


### PR DESCRIPTION
### Motivation
- Fix missing English labels in the simplified mode so the Scoring subtab and Consolidated View show localized text when switching to `en`.
- Keep translations and DOM wiring consistent between HTML and JS so labels update live on language toggle.
- Update the app version displayed and used by the simplified-mode default data to keep the release number in sync; new version is `2.1.36`.

### Description
- Added new translation keys in `assets/js/simple-mode.js` for `matrixProbabilityAxis`, `matrixImpactAxis`, `overviewSortedTitle` and `overviewMatrixTitle` for both `fr` and `en` locales and bumped `DEFAULT_DATA.version` to `2.1.36`.
- Updated `applyLanguage()` in `assets/js/simple-mode.js` to set the new DOM texts so axis labels and overview titles switch immediately on language toggle.
- Bound the new DOM nodes in `init()` by adding `dom.matrixProbabilityAxis`, `dom.matrixImpactAxis`, `dom.overviewSortedTitle`, and `dom.overviewMatrixTitle`.
- Added IDs in `CartoModel.html` for the simplified-mode matrix axis and overview headings, and updated document title, CSS cache-buster and footer version to `2.1.36`.

### Testing
- Ran `node --check assets/js/simple-mode.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf4073e6c832e813154ae560c5174)