### PR TITLE
Ajout cases LFB USA/EuroPlasma au scoring simplifié + export CSV (version 2.1.37)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -248,6 +248,17 @@ Cadeau inapproprié à un agent public"></textarea>
                             <div>
                                 <div class="simple-caption" id="simpleSelectedCaption">Scénario sélectionné</div>
                                 <h3 id="simpleCurrentScenario" class="simple-current-scenario">Aucun scénario sélectionné</h3>
+                                <div class="simple-entities-row" id="simpleEntitiesRow">
+                                    <span class="simple-entities-label" id="simpleEntitiesLabel">Applicable à :</span>
+                                    <label class="simple-entity-option">
+                                        <input type="checkbox" id="simpleEntityLfbUsa">
+                                        <span>LFB USA</span>
+                                    </label>
+                                    <label class="simple-entity-option">
+                                        <input type="checkbox" id="simpleEntityEuroplasma">
+                                        <span>EuroPlasma</span>
+                                    </label>
+                                </div>
                             </div>
                             <div class="simple-sticky-actions">
                                 <button class="btn btn-secondary" id="simpleDuplicateBtn">Dupliquer ce scénario</button>
@@ -719,7 +730,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.36</span>
+            <span class="app-version">Version 2.1.37</span>
         </footer>
     </div>
 
@@ -1123,6 +1134,6 @@ Cadeau inapproprié à un agent public"></textarea>
     <script defer src="assets/js/rms.core.js?v=2.1.29"></script>
     <script defer src="assets/js/rms.integrations.js?v=2.1.29"></script>
     <script defer src="assets/js/main.js?v=2.1.29"></script>
-    <script defer src="assets/js/simple-mode.js?v=2.1.29"></script>
+    <script defer src="assets/js/simple-mode.js?v=2.1.37"></script>
 </body>
 </html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2577,6 +2577,28 @@ tbody tr:hover {
     min-height: 3.2em;
 }
 
+.simple-entities-row {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.simple-entities-label {
+    color: #475467;
+    font-size: 0.92rem;
+    font-weight: 600;
+}
+
+.simple-entity-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: #344054;
+    font-size: 0.92rem;
+}
+
 .simple-matrix-layout {
     display: grid;
     grid-template-columns: minmax(280px, 550px) minmax(255px, 1fr);

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.36',
+        version: '2.1.37',
         scenarios: [],
         selectedId: null,
         updatedAt: null,
@@ -132,6 +132,7 @@ Cadeau inapproprié à un agent public`,
             loadScenarios: 'Charger les scénarios',
             scenariosHelper: 'Les scénarios remplacent la liste actuelle.',
             selectedScenarioCaption: 'Scénario sélectionné',
+            entitiesLabel: 'Applicable à :',
             duplicateScenario: 'Dupliquer ce scénario',
             deleteScenarioLabel: 'Supprimer ce scénario',
             rawRiskTitle: 'Risque brut',
@@ -165,6 +166,7 @@ Inappropriate gift to a public official`,
             loadScenarios: 'Load scenarios',
             scenariosHelper: 'Loading replaces the current list.',
             selectedScenarioCaption: 'Selected scenario',
+            entitiesLabel: 'Applies to:',
             duplicateScenario: 'Duplicate this scenario',
             deleteScenarioLabel: 'Delete this scenario',
             rawRiskTitle: 'Raw risk',
@@ -294,7 +296,8 @@ Inappropriate gift to a public official`,
                     },
                     aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
                     effectiveness: nearestEffectivenessLevel(s.effectiveness),
-                    comment: s.comment || ''
+                    comment: s.comment || '',
+                    appliesTo: normalizeAppliesTo(s.appliesTo)
                 }));
 
             state.data = {
@@ -355,7 +358,8 @@ Inappropriate gift to a public official`,
             raw: { prob: 1, impact: 1 },
             aggravatingFactors: [],
             effectiveness: EFFECTIVENESS_LEVELS[0].value,
-            comment: ''
+            comment: '',
+            appliesTo: { lfbUsa: false, europlasma: false }
         }));
         state.data.selectedId = state.data.scenarios[0]?.id || null;
         state.highlightedScenarioId = state.data.selectedId;
@@ -371,7 +375,8 @@ Inappropriate gift to a public official`,
             id: uid(),
             text: `${current.text} (copie)`,
             raw: { ...current.raw },
-            aggravatingFactors: [...(current.aggravatingFactors || [])]
+            aggravatingFactors: [...(current.aggravatingFactors || [])],
+            appliesTo: normalizeAppliesTo(current.appliesTo)
         };
         const index = state.data.scenarios.findIndex((s) => s.id === current.id);
         state.data.scenarios.splice(index + 1, 0, cloned);
@@ -418,6 +423,13 @@ Inappropriate gift to a public official`,
         if (!Array.isArray(value)) return [];
         const allowed = new Set(getAggravatingFactors().map((factor) => factor.id));
         return [...new Set(value.map((item) => String(item)).filter((id) => allowed.has(id)))];
+    }
+
+    function normalizeAppliesTo(value) {
+        return {
+            lfbUsa: Boolean(value?.lfbUsa),
+            europlasma: Boolean(value?.europlasma)
+        };
     }
 
     function goToScenario(step) {
@@ -610,6 +622,8 @@ Inappropriate gift to a public official`,
         dom.nextBtn.disabled = disabled;
         dom.effectiveness.disabled = disabled;
         dom.comment.disabled = disabled;
+        dom.entityLfbUsa.disabled = disabled;
+        dom.entityEuroplasma.disabled = disabled;
         renderAggravatingFactors(scenario);
 
         if (!scenario) {
@@ -619,6 +633,8 @@ Inappropriate gift to a public official`,
             dom.effectiveness.value = 0;
             dom.effectivenessLegend.textContent = '0% - Inefficace';
             dom.comment.value = '';
+            dom.entityLfbUsa.checked = false;
+            dom.entityEuroplasma.checked = false;
             renderAssessmentProgress();
             return;
         }
@@ -641,6 +657,9 @@ Inappropriate gift to a public official`,
         dom.effectiveness.value = snappedEffectiveness;
         dom.effectivenessLegend.textContent = `${snappedEffectiveness}% - ${effectivenessLabel(snappedEffectiveness)}`;
         dom.comment.value = scenario.comment;
+        const appliesTo = normalizeAppliesTo(scenario.appliesTo);
+        dom.entityLfbUsa.checked = appliesTo.lfbUsa;
+        dom.entityEuroplasma.checked = appliesTo.europlasma;
 
         const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
         dom.prevBtn.disabled = idx <= 0;
@@ -847,6 +866,7 @@ Inappropriate gift to a public official`,
         if (dom.loadScenariosBtn) dom.loadScenariosBtn.textContent = locale.loadScenarios;
         if (dom.scenariosHelper) dom.scenariosHelper.textContent = locale.scenariosHelper;
         if (dom.selectedCaption) dom.selectedCaption.textContent = locale.selectedScenarioCaption;
+        if (dom.entitiesLabel) dom.entitiesLabel.textContent = locale.entitiesLabel;
         if (dom.duplicateBtn) dom.duplicateBtn.textContent = locale.duplicateScenario;
         if (dom.deleteBtn) {
             dom.deleteBtn.textContent = `🗑️ ${locale.deleteScenarioLabel}`;
@@ -938,6 +958,8 @@ Inappropriate gift to a public official`,
             'Risque',
             'Probabilité',
             'Impact',
+            'LFB USA',
+            'EuroPlasma',
             'Facteurs aggravants',
             'Efficacité des mesures',
             'Commentaire'
@@ -947,13 +969,14 @@ Inappropriate gift to a public official`,
             const risk = scenario.text || '';
             const probability = clampMatrixValue(scenario.raw?.prob);
             const impact = clampMatrixValue(scenario.raw?.impact);
+            const appliesTo = normalizeAppliesTo(scenario.appliesTo);
             const aggravatingFactors = (scenario.aggravatingFactors || [])
                 .map((id) => factorsLabelById.get(id) || id)
                 .join(' | ');
             const effectiveness = `${nearestEffectivenessLevel(scenario.effectiveness)}% - ${effectivenessLabel(scenario.effectiveness)}`;
             const comment = scenario.comment || '';
 
-            return [risk, probability, impact, aggravatingFactors, effectiveness, comment];
+            return [risk, probability, impact, appliesTo.lfbUsa ? 'Oui' : 'Non', appliesTo.europlasma ? 'Oui' : 'Non', aggravatingFactors, effectiveness, comment];
         });
 
         const csvContent = [header, ...rows]
@@ -990,7 +1013,8 @@ Inappropriate gift to a public official`,
                     },
                     aggravatingFactors: normalizeAggravatingFactors(s.aggravatingFactors),
                     effectiveness: nearestEffectivenessLevel(s.effectiveness),
-                    comment: s.comment || ''
+                    comment: s.comment || '',
+                    appliesTo: normalizeAppliesTo(s.appliesTo)
                 })).filter((s) => s.text);
                 state.data.selectedId = parsed.selectedId && state.data.scenarios.some((s) => s.id === parsed.selectedId)
                     ? parsed.selectedId
@@ -1024,6 +1048,18 @@ Inappropriate gift to a public official`,
 
         dom.comment.addEventListener('input', (evt) => {
             updateCurrentScenario({ comment: evt.target.value });
+        });
+        dom.entityLfbUsa.addEventListener('change', () => {
+            const current = getSelectedScenario();
+            if (!current) return;
+            const appliesTo = normalizeAppliesTo(current.appliesTo);
+            updateCurrentScenario({ appliesTo: { ...appliesTo, lfbUsa: dom.entityLfbUsa.checked } });
+        });
+        dom.entityEuroplasma.addEventListener('change', () => {
+            const current = getSelectedScenario();
+            if (!current) return;
+            const appliesTo = normalizeAppliesTo(current.appliesTo);
+            updateCurrentScenario({ appliesTo: { ...appliesTo, europlasma: dom.entityEuroplasma.checked } });
         });
 
         dom.exportBtn.addEventListener('click', exportData);
@@ -1098,6 +1134,9 @@ Inappropriate gift to a public official`,
         dom.effectivenessLegend = document.getElementById('simpleEffectivenessLegend');
         dom.comment = document.getElementById('simpleComment');
         dom.commentLabel = document.getElementById('simpleCommentLabel');
+        dom.entitiesLabel = document.getElementById('simpleEntitiesLabel');
+        dom.entityLfbUsa = document.getElementById('simpleEntityLfbUsa');
+        dom.entityEuroplasma = document.getElementById('simpleEntityEuroplasma');
         dom.prevBtn = document.getElementById('simplePrevBtn');
         dom.nextBtn = document.getElementById('simpleNextBtn');
         dom.exportBtn = document.getElementById('simpleExportBtn');


### PR DESCRIPTION
### Motivation
- Permettre d'indiquer, pour chaque scénario en vue simplifiée (onglet Scoring), si le risque s'applique à LFB USA et/ou EuroPlasma et d'exporter cette information dans le CSV ; la version de l'app est également incrémentée à `2.1.37`.

### Description
- Ajout d'un bloc UI horizontal avec deux cases à cocher sous le scénario sélectionné dans `CartoModel.html` pour `LFB USA` et `EuroPlasma` et mise à jour du footer en `Version 2.1.37` et du cache-buster du script `simple-mode.js`.
- Ajout de styles dans `assets/css/main.css` pour l'affichage horizontal et l'apparence des options d'entité (`.simple-entities-row`, `.simple-entity-option`, etc.).
- Extension du modèle de données de la vue simplifiée dans `assets/js/simple-mode.js` avec un champ `appliesTo` par scénario, accompagnée de `normalizeAppliesTo`, gestion lors de la création/duplication/import/chargement local, rendu UI (checked/disabled) et synchronisation via listeners `change`.
- Enrichissement de l'export CSV (`exportCsvData`) pour insérer les colonnes `LFB USA` et `EuroPlasma` (valeurs `Oui`/`Non`).

### Testing
- Exécution de la vérification syntaxique JavaScript via `node --check assets/js/simple-mode.js` qui a réussi.
- Vérification des changements avec `git status --short` et `git show --stat` pour confirmer les fichiers modifiés, qui ont affiché les 3 fichiers touchés (`CartoModel.html`, `assets/css/main.css`, `assets/js/simple-mode.js`).
- Tests manuels de rendu non exécutés ici (environnement headless), mais liaisons UI↔données, import/export et duplication ont été codées et sauvegardées dans le stockage local via les fonctions existantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf526d5e4832e9643d012746eae68)