### PR TITLE
Corrige la version simplifiée (boutons) et passe la version à 2.1.38

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.36</title>
-    <link rel="stylesheet" href="assets/css/main.css?v=2.1.36">
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.1.38</title>
+    <link rel="stylesheet" href="assets/css/main.css?v=2.1.38">
     <!-- Local libraries for offline use -->
     <script src="assets/libs/chart.umd.min.js"></script>
     <script src="assets/libs/html2canvas.min.js"></script>
@@ -730,7 +730,7 @@ Cadeau inapproprié à un agent public"></textarea>
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.1.37</span>
+            <span class="app-version">Version 2.1.38</span>
         </footer>
     </div>
 

--- a/assets/js/simple-mode.js
+++ b/assets/js/simple-mode.js
@@ -1,7 +1,7 @@
 (function () {
     const STORAGE_KEY = 'rmsSimpleModeData';
     const DEFAULT_DATA = {
-        version: '2.1.37',
+        version: '2.1.38',
         scenarios: [],
         selectedId: null,
         updatedAt: null,
@@ -26,19 +26,19 @@
     const PROBABILITY_LEGEND_BY_LANGUAGE = {
         fr: {
             1: {
-                title: 'Probabilité en l'absence de procédures – Peu probable',
+                title: "Probabilité en l'absence de procédures – Peu probable",
                 details: ['Événement non survenu sur les 5 dernières années.', 'Événement non attendu sur les 5 prochaines années.']
             },
             2: {
-                title: 'Probabilité en l'absence de procédures – Moyennement probable',
+                title: "Probabilité en l'absence de procédures – Moyennement probable",
                 details: ['Événement survenu 1 fois au cours des 5 dernières années.', 'Événement pouvant survenir 1 fois au cours des 5 prochaines années.']
             },
             3: {
-                title: 'Probabilité en l'absence de procédures – Probable',
+                title: "Probabilité en l'absence de procédures – Probable",
                 details: ['Événement survenu 1 fois au cours de l’année passée.', 'Événement pouvant survenir 1 fois au cours de l’année à venir.']
             },
             4: {
-                title: 'Probabilité en l'absence de procédures – Très probable',
+                title: "Probabilité en l'absence de procédures – Très probable",
                 details: ['Événement survenu plusieurs fois au cours de l’année passée.', 'Événement attendu 1 ou plusieurs fois au cours de l’année à venir.']
             }
         },


### PR DESCRIPTION
### Motivation
- Corriger une régression qui empêchait le parsing de `assets/js/simple-mode.js` (des apostrophes non échappées dans les libellés FR) et qui bloquait le binding des boutons de la "version simplifiée". 
- Mettre à jour le numéro de version affiché dans le footer et les références associées conformément à la consigne de versioning pour chaque tâche (`2.1.38`).

### Description
- Remplacement des chaînes problématiques dans `PROBABILITY_LEGEND_BY_LANGUAGE.fr` de `assets/js/simple-mode.js` pour éviter les apostrophes non échappées (passage à des guillemets doubles). 
- Bump de la donnée simplifiée `DEFAULT_DATA.version` à `2.1.38` dans `assets/js/simple-mode.js` pour refléter la modification. 
- Mise à jour des références d'app version dans `CartoModel.html` (titre de page, cache-buster CSS `assets/css/main.css?v=...` et la `span.app-version` dans le footer) vers `2.1.38`.

### Testing
- Exécution de la vérification de syntaxe JavaScript avec `node --check assets/js/simple-mode.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de29025a80832e8af0683b17065b7a)