### PR TITLE
feat(matrix): add inline edit button to matrix risk list and bump version to 2.14.26

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -753,7 +753,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.25</span>
+            <span class="app-version">Version 2.14.26</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1536,6 +1536,33 @@ body.feedback-mode-paused .feedback-panel * {
 .risk-item-score.high { background: #e67e22; }
 .risk-item-score.critical { background: var(--danger-color); }
 
+.risk-item-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.risk-item-edit-btn {
+    width: 24px;
+    height: 24px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--surface-color);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8em;
+    line-height: 1;
+    transition: all 0.2s ease;
+}
+
+.risk-item-edit-btn:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+    background: rgba(11, 61, 96, 0.08);
+}
+
 .risk-item-meta {
     font-size: 0.85em;
     color: var(--muted-text-color);

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -7582,7 +7582,16 @@ class RiskManagementSystem {
                     <div class="risk-item" data-risk-id="${risk.id}" onclick="rms.selectRisk(${JSON.stringify(risk.id)})">
                         <div class="risk-item-header">
                             <span class="risk-item-title">${risk.description}</span>
-                            <span class="risk-item-score ${scoreClass}">${formattedScore}</span>
+                            <div class="risk-item-actions">
+                                <span class="risk-item-score ${scoreClass}">${formattedScore}</span>
+                                <button
+                                    type="button"
+                                    class="risk-item-edit-btn"
+                                    title="Éditer le risque"
+                                    aria-label="Éditer le risque ${risk.description}"
+                                    onclick="event.stopPropagation(); rms.editRisk(${JSON.stringify(risk.id)})"
+                                >✏️</button>
+                            </div>
                         </div>
                         <div class="risk-item-meta">
                             ${metaDetails}


### PR DESCRIPTION
### Motivation
- Faciliter l'édition rapide d'un risque directement depuis le panneau de détails de la Matrice sans sélectionner l'élément et ouvrir le formulaire manuellement.
- Garder l'interface compacte et accessible en ajoutant une action dédiée sur chaque ligne de risque.
- Respecter la règle de versioning demandée en mettant à jour le numéro de version dans le footer.

### Description
- Ajout d'un bouton compact d'édition (✏️) inline dans chaque élément de la liste des risques de l'onglet Matrice qui appelle `rms.editRisk(...)` et utilise `event.stopPropagation()` pour éviter la sélection lors du clic (`assets/js/rms.core.js`).
- Ajout des styles associés `risk-item-actions` et `risk-item-edit-btn` pour un rendu compact et un état hover (`assets/css/main.css`).
- Mise à jour du numéro de version dans le footer de l'application à `Version 2.14.26` (`CartoModel.html`).
- Fichiers modifiés : `assets/js/rms.core.js`, `assets/css/main.css`, `CartoModel.html`.

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check assets/js/rms.core.js` qui a réussi.
- Exécution de la vérification syntaxique JavaScript avec `node --check assets/js/main.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b9b9f5b4832ea7d9f08384412097)