### PR TITLE
Ajout de l'autocomplétion sur les avantages attendus

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.27</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.30</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.29</span>
+            <span class="app-version">Version 2.14.30</span>
         </footer>
     </div>
 
@@ -1220,7 +1220,8 @@
                                 <div class="form-group">
                                     <label class="form-label">Avantages attendus</label>
                                     <div class="chip-input-wrapper">
-                                        <input class="form-input" id="expectedBenefitsInput" type="text" placeholder="Saisir un avantage attendu puis Entrée">
+                                        <input class="form-input" id="expectedBenefitsInput" type="text" list="expectedBenefitsSuggestions" placeholder="Saisir un avantage attendu puis Entrée">
+                                        <datalist id="expectedBenefitsSuggestions"></datalist>
                                         <button class="btn btn-outline" type="button" onclick="addRiskChip('expected')">Ajouter</button>
                                     </div>
                                     <div class="risk-chip-list" id="expectedBenefitsChips"></div>

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -345,7 +345,7 @@ function normalizeBenefitForMatching(value) {
         .join(' ');
 }
 
-function buildUndueBenefitsDictionary() {
+function buildBenefitsDictionary(kind) {
     const dictionary = new Map();
     const addValue = (candidate) => {
         const label = typeof candidate === 'string' ? candidate.trim() : (candidate != null ? String(candidate).trim() : '');
@@ -355,21 +355,24 @@ function buildUndueBenefitsDictionary() {
         dictionary.set(normalized, label);
     };
 
-    (riskBenefitsState.undue || []).forEach(addValue);
+    const stateKey = kind === 'expected' ? 'expected' : 'undue';
+    const riskKey = kind === 'expected' ? 'avantagesAttendus' : 'avantagesIndus';
+
+    (riskBenefitsState[stateKey] || []).forEach(addValue);
     (rms?.risks || []).forEach(risk => {
-        (risk?.avantagesIndus || []).forEach(addValue);
+        (risk?.[riskKey] || []).forEach(addValue);
     });
 
     return dictionary;
 }
 
-function findClosestExistingUndueBenefitLabel(value) {
+function findClosestExistingBenefitLabel(value, kind) {
     const source = typeof value === 'string' ? value.trim() : '';
     if (!source) return '';
     const normalized = normalizeBenefitForMatching(source);
     if (!normalized) return '';
     const tokens = new Set(normalized.split(' ').filter(Boolean));
-    const dictionary = buildUndueBenefitsDictionary();
+    const dictionary = buildBenefitsDictionary(kind);
 
     if (dictionary.has(normalized)) {
         return dictionary.get(normalized) || '';
@@ -391,10 +394,10 @@ function findClosestExistingUndueBenefitLabel(value) {
     return '';
 }
 
-function refreshUndueBenefitsAutocomplete() {
-    const datalist = document.getElementById('undueBenefitsSuggestions');
+function refreshBenefitsAutocomplete(kind) {
+    const datalist = document.getElementById(kind === 'expected' ? 'expectedBenefitsSuggestions' : 'undueBenefitsSuggestions');
     if (!datalist) return;
-    const dictionary = buildUndueBenefitsDictionary();
+    const dictionary = buildBenefitsDictionary(kind);
     const options = Array.from(dictionary.values()).sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
     datalist.innerHTML = options
         .map(label => `<option value="${label.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}"></option>`)
@@ -426,8 +429,10 @@ function renderRiskChipList(kind) {
             <button type="button" class="risk-chip-remove" onclick="removeRiskChip('${kind}', ${index})" aria-label="Supprimer ${chip}">×</button>
         </span>
     `).join('');
+    if (kind === 'undue' || kind === 'expected') {
+        refreshBenefitsAutocomplete(kind);
+    }
     if (kind === 'undue') {
-        refreshUndueBenefitsAutocomplete();
         renderBenefitFirstAssignment();
         updateSelectedControlsDisplay();
     }
@@ -456,9 +461,7 @@ function addRiskChip(kind) {
     if (!input) return;
     const value = input.value.trim();
     if (!value) return;
-    const resolvedValue = kind === 'undue'
-        ? (findClosestExistingUndueBenefitLabel(value) || value)
-        : value;
+    const resolvedValue = findClosestExistingBenefitLabel(value, kind) || value;
     const existing = Array.isArray(riskBenefitsState[kind]) ? riskBenefitsState[kind] : [];
     if (!existing.some(item => normalizeBenefitForMatching(item) === normalizeBenefitForMatching(resolvedValue))) {
         existing.push(resolvedValue);
@@ -1895,7 +1898,16 @@ function bindEvents() {
         if (inputId === 'undueBenefitsInput') {
             input.addEventListener('blur', () => {
                 if (!input.value.trim()) return;
-                const existingLabel = findClosestExistingUndueBenefitLabel(input.value);
+                const existingLabel = findClosestExistingBenefitLabel(input.value, 'undue');
+                if (existingLabel) {
+                    input.value = existingLabel;
+                }
+            });
+        }
+        if (inputId === 'expectedBenefitsInput') {
+            input.addEventListener('blur', () => {
+                if (!input.value.trim()) return;
+                const existingLabel = findClosestExistingBenefitLabel(input.value, 'expected');
                 if (existingLabel) {
                     input.value = existingLabel;
                 }
@@ -1909,7 +1921,8 @@ function bindEvents() {
         });
     });
 
-    refreshUndueBenefitsAutocomplete();
+    refreshBenefitsAutocomplete('undue');
+    refreshBenefitsAutocomplete('expected');
 
     document.addEventListener('click', (e) => {
         const editBtn = e.target.closest('.control-action-btn.edit');


### PR DESCRIPTION
### Motivation
- Rendre l’expérience de saisie des `Avantages attendus` cohérente avec celle des `Avantages indus` en réutilisant la même logique d’autocomplétion et de rapprochement flou des libellés. 
- Mettre à jour la version affichée dans l’interface comme demandé, en passant à `2.14.30`.

### Description
- Ajout d’une `datalist` dédiée `expectedBenefitsSuggestions` et du `list` sur le champ `#expectedBenefitsInput` dans `CartoModel.html` afin d’exposer les suggestions côté UI. 
- Généralisation de la logique JS d’autocomplete par la création de `buildBenefitsDictionary(kind)`, `findClosestExistingBenefitLabel(value, kind)` et `refreshBenefitsAutocomplete(kind)` dans `assets/js/rms.ui.js`. 
- Alignement du comportement UX pour les deux champs (`undue` et `expected`) : résolution floue au `blur`, rapprochement lors de l’ajout via `addRiskChip` et rafraîchissement des deux listes de suggestions. 
- Mise à jour du numéro de version affiché dans le titre et le footer à `2.14.30` dans `CartoModel.html`.

### Testing
- Vérification statique du fichier modifié avec `node --check assets/js/rms.ui.js` réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cfef9424832eb774b8995bea16f1)