### PR TITLE
Corrige l'espacement des boutons des modales et mise à jour version 2.14.32

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.30</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.32</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.31</span>
+            <span class="app-version">Version 2.14.32</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2198,6 +2198,14 @@ tbody tr:hover {
     min-width: 220px;
 }
 
+
+.form-actions {
+    display: flex;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 0 30px 24px;
+}
+
 .modal-footer {
     background: var(--light-bg);
     padding: 20px 30px;


### PR DESCRIPTION
### Motivation
- Les boutons d'action des modales d'association (sélection de contrôles / plans d'action lors de la création d'un risque) étaient collés au cadre, rendant l'interface serrée et peu lisible.  

### Description
- Ajout d'une règle CSS `.form-actions` dans `assets/css/main.css` pour appliquer `display: flex`, un `gap` entre boutons et un `padding` afin d'éloigner les boutons du bord de la modal.  
- Mise à jour des références de version dans `CartoModel.html` pour aligner le titre et le footer sur `2.14.32` (version mise à jour : `2.14.32`).

### Testing
- Vérification des changements par `rg -n "\.form-actions|Version 2\.14\.32|Sapin 2 v2\.14\.32"` qui a confirmé l'ajout du sélecteur et la mise à jour des chaînes de version (succès).  
- Commit Git effectué avec le message `Fix modal action spacing and bump footer version` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d5756c04832eaaa8ece0147f9c9a)