### PR TITLE
Enregistrer en brouillon les éléments incomplets et mise à jour version 2.14.33

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.32</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.33</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.32</span>
+            <span class="app-version">Version 2.14.33</span>
         </footer>
     </div>
 
@@ -916,7 +916,7 @@
                 <button class="modal-close" onclick="closeControlModal()">&times;</button>
             </div>
             <div class="modal-body">
-                <form id="controlForm" onsubmit="saveControl(); return false;">
+                <form id="controlForm" onsubmit="saveControl(); return false;" novalidate>
                     <div class="form-section">
                         <div class="form-section-title">Informations Générales</div>
                         <div class="form-grid">
@@ -1000,7 +1000,7 @@
                 <button class="modal-close" onclick="closeActionPlanModal()">&times;</button>
             </div>
             <div class="modal-body">
-                <form id="actionPlanForm" onsubmit="saveActionPlan(); return false;">
+                <form id="actionPlanForm" onsubmit="saveActionPlan(); return false;" novalidate>
                     <div class="form-section">
                         <div class="form-section-title">Informations Générales</div>
                         <div class="form-grid">

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2364,6 +2364,16 @@ function applyPatch() {
       function setControlFieldValue(fieldId, value) {
         const field = document.getElementById(fieldId);
         if (field) {
+          if (field.tagName === 'SELECT' && value) {
+            const normalizedValue = String(value);
+            const hasOption = Array.from(field.options || []).some(option => option.value === normalizedValue);
+            if (!hasOption) {
+              const option = document.createElement('option');
+              option.value = normalizedValue;
+              option.textContent = normalizedValue;
+              field.appendChild(option);
+            }
+          }
           field.value = value || '';
         }
       }
@@ -2592,7 +2602,7 @@ function applyPatch() {
         if (!form) return;
         const formData = new FormData(form);
         const controlData = {
-          name: formData.get('name'),
+          name: String(formData.get('name') || '').trim(),
           type: formData.get('type'),
           origin: formData.get('origin'),
           owner: formData.get('owner'),
@@ -2603,10 +2613,12 @@ function applyPatch() {
           description: formData.get('description'),
           risks: [...selectedRisksForControl]
         };
-
-        if (!controlData.name) {
-          alert('Veuillez renseigner le nom du contrôle.');
-          return;
+        const isDraftControl = !controlData.name;
+        if (isDraftControl) {
+          controlData.name = `Contrôle brouillon (${new Date().toLocaleDateString('fr-FR')})`;
+        }
+        if (!controlData.status || isDraftControl) {
+          controlData.status = 'brouillon';
         }
 
         let resultingControlId = currentEditingControlId || null;
@@ -2622,7 +2634,11 @@ function applyPatch() {
               ...controlData
             };
             addHistoryItem("Modification contrôle", `Contrôle "${controlData.name}" (ID ${currentEditingControlId}) mis à jour.`, {id: currentEditingControlId, name: controlData.name});
-            toast(`Contrôle "${controlData.name}" modifié avec succès`);
+            if (isDraftControl) {
+              toast('Contrôle incomplet enregistré en brouillon');
+            } else {
+              toast(`Contrôle "${controlData.name}" modifié avec succès`);
+            }
           }
         } else {
           const newControl = {
@@ -2634,7 +2650,11 @@ function applyPatch() {
           state.controls.push(newControl);
           resultingControlId = newControl.id;
           addHistoryItem("Nouveau contrôle", `Nouveau contrôle "${controlData.name}" créé (ID ${newControl.id}).`, {id: newControl.id, name: controlData.name});
-          toast(`Contrôle "${controlData.name}" créé avec succès`);
+          if (isDraftControl) {
+            toast('Contrôle incomplet enregistré en brouillon');
+          } else {
+            toast(`Contrôle "${controlData.name}" créé avec succès`);
+          }
         }
 
         if (context && resultingControlId != null) {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1046,10 +1046,12 @@ function saveRisk() {
     formData.probPost = formData.probNet;
     formData.impactPost = formData.impactNet;
 
-    // Validate form
-    if (!formData.processusAssocies.length || !formData.description || !formData.typesCorruption.length || !formData.statut) {
-        showNotification('error', 'Veuillez remplir tous les champs obligatoires');
-        return;
+    const isIncompleteRisk = !formData.processusAssocies.length
+        || !formData.description
+        || !formData.typesCorruption.length
+        || !formData.statut;
+    if (isIncompleteRisk) {
+        formData.statut = 'brouillon';
     }
 
     if (currentEditingRiskId) {
@@ -1087,7 +1089,11 @@ function saveRisk() {
             rms.saveData();
             rms.init();
             closeModal('riskModal');
-            showNotification('success', 'Risque mis à jour avec succès!');
+            if (isIncompleteRisk) {
+                showNotification('info', 'Risque incomplet enregistré en brouillon');
+            } else {
+                showNotification('success', 'Risque mis à jour avec succès!');
+            }
             currentEditingRiskId = null;
         }
     } else {
@@ -1116,7 +1122,11 @@ function saveRisk() {
         rms.saveData();
         rms.renderAll();
         closeModal('riskModal');
-        showNotification('success', 'Risque ajouté avec succès!');
+        if (isIncompleteRisk) {
+            showNotification('info', 'Risque incomplet enregistré en brouillon');
+        } else {
+            showNotification('success', 'Risque ajouté avec succès!');
+        }
     }
 
     if (rms) {
@@ -1584,15 +1594,22 @@ function saveActionPlan() {
     const form = document.getElementById('actionPlanForm');
     if (!form) return;
     const formData = new FormData(form);
+    const planTitle = String(formData.get('title') || '').trim();
     const planData = {
-        title: formData.get('title').trim(),
+        title: planTitle,
         owner: formData.get('owner').trim(),
         dueDate: formData.get('dueDate'),
         status: formData.get('status'),
         description: formData.get('description').trim(),
         risks: [...selectedRisksForPlan]
     };
-    if (!planData.title) { alert('Titre requis'); return; }
+    const isDraftPlan = !planData.title;
+    if (isDraftPlan) {
+        planData.title = `Brouillon sans titre (${new Date().toLocaleDateString('fr-FR')})`;
+    }
+    if (!planData.status || isDraftPlan) {
+        planData.status = 'brouillon';
+    }
 
     let resultingPlanId = currentEditingActionPlanId || null;
     const context = (actionPlanCreationContext && actionPlanCreationContext.fromRisk)
@@ -1613,7 +1630,11 @@ function saveActionPlan() {
                     risk.actionPlans = risk.actionPlans.filter(id => !idsEqual(id, currentEditingActionPlanId));
                 }
             });
-            showNotification('success', `Plan "${planData.title}" modifié`);
+            if (isDraftPlan) {
+                showNotification('info', 'Plan incomplet enregistré en brouillon');
+            } else {
+                showNotification('success', `Plan "${planData.title}" modifié`);
+            }
         }
     } else {
         const newPlan = { id: getNextSequentialId(rms.actionPlans), ...planData };
@@ -1626,7 +1647,11 @@ function saveActionPlan() {
                 if (!risk.actionPlans.some(id => idsEqual(id, newPlan.id))) risk.actionPlans.push(newPlan.id);
             }
         });
-        showNotification('success', `Plan "${planData.title}" créé`);
+        if (isDraftPlan) {
+            showNotification('info', 'Plan incomplet enregistré en brouillon');
+        } else {
+            showNotification('success', `Plan "${planData.title}" créé`);
+        }
     }
 
     if (context && resultingPlanId != null) {


### PR DESCRIPTION
### Motivation
- Autoriser la sauvegarde même si des champs obligatoires ne sont pas complétés afin de ne pas bloquer la saisie et permettre la reprise ultérieure (risques, contrôles, plans d'action).
- Mettre à jour la version affichée dans l'UI pour refléter la modification.

### Description
- Risques: `assets/js/rms.ui.js` modifié pour ne plus bloquer la sauvegarde when required fields are missing; le formulaire force alors `statut = 'brouillon'` et enregistre l'élément tout en affichant une notification d'information.
- Plans d'action: `assets/js/rms.ui.js` modifié pour accepter un plan sans titre en générant un titre de type `Brouillon sans titre (jj/mm/aaaa)` et en forçant `status = 'brouillon'` si nécessaire.
- Contrôles: `assets/js/rms.integrations.js` modifié pour accepter un contrôle sans nom en générant un nom de brouillon et en forçant `status = 'brouillon'` si nécessaire, et pour nettoyer/trimper le nom saisi.
- Réouverture/édition: ajout d'une logique dans `assets/js/rms.integrations.js` pour injecter dynamiquement une option manquante dans un `<select>` (utile pour afficher un statut non présent initialement, p.ex. `brouillon`).
- Formulaires HTML: ajout de l'attribut `novalidate` aux formulaires contrôle et plan d'action dans `CartoModel.html` pour éviter que la validation HTML native empêche l'enregistrement en brouillon.
- Version UI: `CartoModel.html` mis à jour pour afficher la version `2.14.33` (titre de page et footer).

### Testing
- `node --check assets/js/rms.ui.js` exécuté avec succès.
- `node --check assets/js/rms.integrations.js` exécuté avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d88cc830832e9bffc89bf27bf06d)