### PR TITLE
Group recommended controls in selector, skip current risk recommendations, add styles, bump version to v2.14.34

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.33</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.34</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.33</span>
+            <span class="app-version">Version 2.14.34</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2926,6 +2926,28 @@ tbody tr:hover {
     color: var(--muted-text-color);
 }
 
+.risk-list-section-title {
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: #475569;
+    margin: 12px 0 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.risk-list-section-title:first-child {
+    margin-top: 0;
+}
+
+.risk-list-empty {
+    padding: 10px;
+    font-size: 0.86rem;
+    color: var(--muted-text-color);
+    border: 1px dashed #cbd5e1;
+    border-radius: 8px;
+    margin-bottom: 8px;
+}
+
 /* Amélioration des contrôles existants */
 .control-item {
     background: var(--surface-color);

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -510,6 +510,9 @@ function getRecommendedControlIdsForBenefit(label) {
     if (!label || !rms || !Array.isArray(rms.risks)) return [];
     const ids = new Set();
     rms.risks.forEach(risk => {
+        if (currentEditingRiskId != null && idsEqual(risk?.id, currentEditingRiskId)) {
+            return;
+        }
         const assignments = Array.isArray(risk?.controlAssignments) ? risk.controlAssignments : [];
         assignments.forEach(entry => {
             if (!entry || entry.controlId == null) return;
@@ -1205,7 +1208,8 @@ function renderControlSelectionList() {
     if (!list || !rms) return;
     const focusContainer = document.getElementById('controlBenefitFocus');
     const focusLabel = currentBenefitFocusForControlSelector;
-    const recommendedSet = new Set(getRecommendedControlIdsForBenefit(focusLabel));
+    const recommendedIds = getRecommendedControlIdsForBenefit(focusLabel);
+    const recommendedSet = new Set(recommendedIds);
     if (focusContainer) {
         focusContainer.innerHTML = focusLabel
             ? `<div class="control-benefit-focus-card">
@@ -1232,12 +1236,17 @@ function renderControlSelectionList() {
             return acc;
         }, {})
         : {};
-    list.innerHTML = rms.controls.filter(ctrl => {
+    const availableControls = rms.controls.filter(ctrl => {
         const name = (ctrl.name || '').toLowerCase();
-        const matchesQuery = String(ctrl.id).includes(query) || name.includes(query);
-        const matchesFocus = !focusLabel || recommendedSet.has(ctrl.id) || selectedControlsForRisk.includes(ctrl.id);
-        return matchesQuery && matchesFocus;
-    }).map(ctrl => {
+        return String(ctrl.id).includes(query) || name.includes(query);
+    });
+    const recommendedControls = focusLabel
+        ? availableControls.filter(ctrl => recommendedSet.has(ctrl.id))
+        : [];
+    const otherControls = focusLabel
+        ? availableControls.filter(ctrl => !recommendedSet.has(ctrl.id))
+        : availableControls;
+    const renderControlItem = ctrl => {
         const isSelected = selectedControlsForRisk.includes(ctrl.id);
         const typeKey = ctrl?.type != null ? String(ctrl.type).toLowerCase() : '';
         const typeLabel = typeKey ? (typeMap[typeKey] || ctrl.type || '') : '';
@@ -1254,7 +1263,25 @@ function renderControlSelectionList() {
                 ${focusLabel && recommendedSet.has(ctrl.id) ? '<div class="risk-item-hint">Recommandé pour cet avantage indu</div>' : ''}
               </div>
             </div>`;
-    }).join('');
+    };
+    const sections = [];
+    if (focusLabel) {
+        sections.push(`
+            <div class="risk-list-section-title">
+                Contrôles déjà assignés à cet avantage dans d'autres risques (${recommendedControls.length})
+            </div>
+            ${recommendedControls.length ? recommendedControls.map(renderControlItem).join('') : '<div class="risk-list-empty">Aucun contrôle recommandé trouvé.</div>'}
+        `);
+        sections.push(`
+            <div class="risk-list-section-title">
+                Autres contrôles disponibles (${otherControls.length})
+            </div>
+            ${otherControls.length ? otherControls.map(renderControlItem).join('') : '<div class="risk-list-empty">Aucun autre contrôle disponible.</div>'}
+        `);
+    } else {
+        sections.push(otherControls.map(renderControlItem).join(''));
+    }
+    list.innerHTML = sections.join('');
 }
 
 function filterControlsForRisk(query) {


### PR DESCRIPTION
### Motivation
- Prevent controls already assigned to the risk being edited from appearing as recommendations for that same risk to avoid circular suggestions.
- Improve the control selector UX by grouping recommended controls and showing clear empty-state messages.
- Bump the app version metadata to `2.14.34`.

### Description
- Updated `getRecommendedControlIdsForBenefit` to ignore the `currentEditingRiskId` when gathering recommended control ids.  
- Refactored `renderControlSelectionList` to compute `availableControls`, `recommendedControls`, and `otherControls`, and to render separate titled sections with counts and empty-state messages; introduced `recommendedIds` for clarity.  
- Added UI affordances in CSS: `.risk-list-section-title` and `.risk-list-empty` to support the new grouped lists and empty states.  
- Updated `CartoModel.html` page title and footer version text from `2.14.33` to `2.14.34`.

### Testing
- Ran the project's linting suite with `npm run lint` and it passed.  
- Executed the existing automated unit tests with `npm test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ec463ebc832ebd334ee4a0c32f38)