### PR TITLE
Permettre la suppression unitaire des contrôles lors de la création/édition d’un risque

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.34</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.35</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.34</span>
+            <span class="app-version">Version 2.14.35</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2770,6 +2770,12 @@ tbody tr:hover {
     gap: 8px;
 }
 
+.control-assignment-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
 .control-assignment-title {
     font-size: 0.9rem;
     font-weight: 600;
@@ -2795,6 +2801,21 @@ tbody tr:hover {
     border-color: #2563eb;
     background: #dbeafe;
     color: #1d4ed8;
+}
+
+.control-assignment-remove-btn {
+    border: 1px solid #ef4444;
+    border-radius: 999px;
+    background: #fff5f5;
+    color: #b91c1c;
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.control-assignment-remove-btn:hover {
+    background: #fee2e2;
 }
 
 .benefit-first-assignment {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1357,11 +1357,13 @@ function updateSelectedControlsDisplay() {
             <div class="control-assignment-card">
                 <div class="control-assignment-header">
                     <div class="control-assignment-title">#${id} - ${name.substring(0, 70)}${name.length > 70 ? '...' : ''}</div>
-                    <div>
+                    <div class="control-assignment-actions">
                         <label style="font-size:0.78rem;">
                             <input type="checkbox" ${assignment.transverse ? 'checked' : ''} onchange="toggleControlTransverse(${id})"> Transverse
                         </label>
-                        <span class="remove-control" onclick="removeControlFromSelection(${id})">×</span>
+                        <button type="button" class="control-assignment-remove-btn" onclick="removeControlFromSelection(${id})" aria-label="Retirer le contrôle #${id}">
+                            Retirer
+                        </button>
                     </div>
                 </div>
                 <div class="control-assignment-tags">${tags}</div>


### PR DESCRIPTION
### Motivation
- Les contrôles associés à un risque devaient pouvoir être retirés un par un depuis le formulaire d'édition/création pour améliorer l'ergonomie de la saisie. 
- La version affichée dans l'interface doit être incrémentée à chaque tâche de modification de l'app (consigne de versioning).  

### Description
- Remplacement de l'icône « × » par un bouton explicite `Retirer` pour chaque contrôle associé et liaison de ce bouton à la fonction existante `removeControlFromSelection`.  
- Ajout d'un conteneur d'actions `control-assignment-actions` pour regrouper l'option `Transverse` et le bouton de suppression, et ajout des styles CSS `control-assignment-remove-btn` et `control-assignment-actions` pour l'ergonomie.  
- Mise à jour du titre de page et du footer pour la `Version 2.14.35`.  
- Fichiers modifiés : `assets/js/rms.ui.js`, `assets/css/main.css`, `CartoModel.html`, sans changement du modèle de données (les tableaux `selectedControlsForRisk` et `controlAssignmentsForRisk` sont toujours mis à jour). 

### Testing
- Exécution de `git diff --check` qui a retourné sans erreur.  
- Vérification de l'état avec `git status --short` confirmant les fichiers modifiés.  
- Le commit a été créé avec succès (modifications ajoutées et engagées).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ee92b940832e98e38bfff9cc782a)