### PR TITLE
UI: Display transverse controls, refine benefit-linking logic, and bump version to v2.14.36

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.35</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.36</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.35</span>
+            <span class="app-version">Version 2.14.36</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2756,6 +2756,38 @@ tbody tr:hover {
     gap: 10px;
 }
 
+.transverse-controls-section {
+    margin-top: 12px;
+    border: 1px solid #cbd5e1;
+    border-radius: 10px;
+    padding: 10px 12px;
+    background: #f8fafc;
+}
+
+.transverse-controls-title {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 8px;
+}
+
+.transverse-controls-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.transverse-control-chip {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.78rem;
+    color: #1f2937;
+    background: #ffffff;
+}
+
 .control-assignment-card {
     border: 1px solid var(--border-color);
     border-radius: 10px;

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -529,7 +529,7 @@ function getAssignedControlNamesForBenefit(label) {
     if (!label || !rms) return [];
     const linked = selectedControlsForRisk.map(controlId => {
         const assignment = controlAssignmentsForRisk[String(controlId)] || {};
-        if (!(assignment.avantagesIndus || []).includes(label) && !assignment.transverse) {
+        if (!(assignment.avantagesIndus || []).includes(label)) {
             return null;
         }
         const control = rms.controls.find(ctrl => ctrl.id === controlId);
@@ -1338,7 +1338,7 @@ function updateSelectedControlsDisplay() {
         return;
     }
     const undueBenefits = Array.isArray(riskBenefitsState.undue) ? riskBenefitsState.undue : [];
-    container.innerHTML = `<div class="controls-assignment-list">${selectedControlsForRisk.map(id => {
+    const cardsHtml = selectedControlsForRisk.map(id => {
         const ctrl = rms.controls.find(c => c.id === id);
         if (!ctrl) return '';
         const name = ctrl.name || 'Sans nom';
@@ -1368,7 +1368,21 @@ function updateSelectedControlsDisplay() {
                 </div>
                 <div class="control-assignment-tags">${tags}</div>
             </div>`;
-    }).join('')}</div>`;
+    }).join('');
+    const transverseControls = selectedControlsForRisk.map(id => {
+        const assignment = controlAssignmentsForRisk[String(id)];
+        if (!assignment?.transverse) return null;
+        const ctrl = rms.controls.find(c => c.id === id);
+        if (!ctrl) return null;
+        return `<span class="transverse-control-chip">#${id} - ${ctrl.name || 'Sans nom'}</span>`;
+    }).filter(Boolean);
+    const transverseSection = transverseControls.length
+        ? `<div class="transverse-controls-section">
+                <div class="transverse-controls-title">Contrôles transverses</div>
+                <div class="transverse-controls-list">${transverseControls.join('')}</div>
+           </div>`
+        : '';
+    container.innerHTML = `<div class="controls-assignment-list">${cardsHtml}</div>${transverseSection}`;
     renderBenefitFirstAssignment();
 }
 window.updateSelectedControlsDisplay = updateSelectedControlsDisplay;
@@ -1389,6 +1403,7 @@ function toggleControlTransverse(controlId) {
         controlAssignmentsForRisk[key] = { transverse: false, avantagesIndus: [] };
     }
     controlAssignmentsForRisk[key].transverse = !controlAssignmentsForRisk[key].transverse;
+    updateSelectedControlsDisplay();
     if (rms && typeof rms.markUnsavedChange === 'function') {
         rms.markUnsavedChange('riskForm');
     }


### PR DESCRIPTION
### Motivation
- Improve how selected controls are displayed by separating and surfacing controls marked as "transverse" and avoid incorrectly counting them as benefit-linked. 
- Add visual styles for the new transverse controls UI and update the app version.

### Description
- Bumped application version in `CartoModel.html` from `2.14.35` to `2.14.36` and updated the footer `Version` label. 
- Added CSS classes in `assets/css/main.css` to style a `transverse-controls-section`, `transverse-controls-title`, `transverse-controls-list`, and `transverse-control-chip`. 
- Updated `assets/js/rms.ui.js` to change benefit-control linking logic by removing the previous special-case that implicitly counted `transverse` assignments as linked in `getAssignedControlNamesForBenefit`, so only controls explicitly linked to a benefit label are returned. 
- Reworked `updateSelectedControlsDisplay` to render control assignment cards and separately render a `Contrôles transverses` section with chips for controls that have `transverse` set; factored HTML assembly into `cardsHtml` and `transverseSection`. 
- Ensured UI stays in sync by calling `updateSelectedControlsDisplay()` from `toggleControlTransverse()` so toggling the transverse flag immediately re-renders the display. 

### Testing
- No automated unit tests were modified for these UI changes and no new automated tests were added. 
- No automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f16a4a24832e979b7c95d0c3c7b0)