### PR TITLE
Supprime le bloc control-benefit-focus-card dans l’assignation des contrôles

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.36</span>
+            <span class="app-version">Version 2.14.37</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1211,15 +1211,7 @@ function renderControlSelectionList() {
     const recommendedIds = getRecommendedControlIdsForBenefit(focusLabel);
     const recommendedSet = new Set(recommendedIds);
     if (focusContainer) {
-        focusContainer.innerHTML = focusLabel
-            ? `<div class="control-benefit-focus-card">
-                    <strong>Attribution pour :</strong> ${focusLabel}
-                    <div class="control-benefit-focus-actions">
-                        <button type="button" class="btn btn-outline" onclick="selectRecommendedControlsForFocusedBenefit()">Sélectionner les recommandés</button>
-                        <button type="button" class="btn btn-outline" onclick="clearControlBenefitFocus()">Voir tous les avantages</button>
-                    </div>
-               </div>`
-            : '';
+        focusContainer.innerHTML = '';
     }
     const query = controlFilterQueryForRisk.toLowerCase();
     const typeMap = Array.isArray(rms.config?.controlTypes)


### PR DESCRIPTION
### Motivation
- Retirer l'affichage du panneau de focus lié aux avantages indus qui rendait la carte `control-benefit-focus-card` dans la sélection des contrôles et mettre à jour la version affichée dans le footer.

### Description
- Vider systématiquement le conteneur `controlBenefitFocus` dans `renderControlSelectionList()` pour ne plus rendre la carte de focus (modification dans `assets/js/rms.ui.js`) et mettre à jour la version du footer de `2.14.36` à `2.14.37` (modification dans `CartoModel.html`).

### Testing
- Vérification syntaxique JavaScript exécutée avec `node --check assets/js/rms.ui.js` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f46ac7b0832ea1070de1002a77da)