### PR TITLE
Add transverse controls & benefit-focused control assignment UI; bump version to v2.14.37

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.36</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.37</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.36</span>
+            <span class="app-version">Version 2.14.37</span>
         </footer>
     </div>
 
@@ -1333,9 +1333,9 @@
                         <div class="form-section-title">Contrôles Associés</div>
                         <div class="controls-section">
                             <button type="button" class="btn btn-secondary" onclick="openControlSelector()">
-                                + Ajouter un contrôle
+                                + Ajouter un contrôle transverse
                             </button>
-                            <div class="form-helper">Astuce : cochez “Transverse” pour un contrôle global, ou cliquez sur les avantages indus pour créer des liens ciblés.</div>
+                            <div class="form-helper">Astuce : utilisez “Ajouter un contrôle transverse” pour un contrôle global, ou “Ajouter un contrôle” depuis un avantage indu pour un lien ciblé.</div>
                             <div class="benefit-first-assignment" id="benefitFirstAssignment"></div>
                             <div class="controls-grid" id="riskControls" style="margin-top: 15px;">
                                 <!-- Selected controls will appear here -->

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2786,6 +2786,17 @@ tbody tr:hover {
     font-size: 0.78rem;
     color: #1f2937;
     background: #ffffff;
+    gap: 6px;
+}
+
+.transverse-control-remove-btn {
+    border: none;
+    background: transparent;
+    color: #b91c1c;
+    cursor: pointer;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0;
 }
 
 .control-assignment-card {
@@ -2887,6 +2898,25 @@ tbody tr:hover {
     margin-top: 4px;
     color: #64748b;
     font-size: 0.78rem;
+}
+
+.benefit-first-linked-controls {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.benefit-first-linked-chip {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid #bfdbfe;
+    border-radius: 999px;
+    padding: 3px 9px;
+    background: #eff6ff;
+    color: #1e3a8a;
+    font-size: 0.74rem;
+    font-weight: 600;
 }
 
 .benefit-first-actions {

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2661,6 +2661,19 @@ function applyPatch() {
           if (!selectedControlsForRisk.some(id => idsEqual(id, resultingControlId))) {
             selectedControlsForRisk.push(resultingControlId);
           }
+          if (window.controlAssignmentsForRisk) {
+            const key = String(resultingControlId);
+            const baseAssignment = window.controlAssignmentsForRisk[key] || { transverse: true, avantagesIndus: [] };
+            const contextBenefit = typeof context.benefitLabel === 'string' ? context.benefitLabel.trim() : '';
+            const nextBenefits = Array.isArray(baseAssignment.avantagesIndus) ? [...baseAssignment.avantagesIndus] : [];
+            if (contextBenefit && !nextBenefits.includes(contextBenefit)) {
+              nextBenefits.push(contextBenefit);
+            }
+            window.controlAssignmentsForRisk[key] = {
+              transverse: contextBenefit ? false : (context.transverse !== false),
+              avantagesIndus: nextBenefits
+            };
+          }
           if (typeof window.updateSelectedControlsDisplay === 'function') {
             window.updateSelectedControlsDisplay();
           }

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -525,17 +525,19 @@ function getRecommendedControlIdsForBenefit(label) {
     return Array.from(ids);
 }
 
-function getAssignedControlNamesForBenefit(label) {
+function getAssignedControlsForBenefit(label) {
     if (!label || !rms) return [];
-    const linked = selectedControlsForRisk.map(controlId => {
+    return selectedControlsForRisk.map(controlId => {
         const assignment = controlAssignmentsForRisk[String(controlId)] || {};
         if (!(assignment.avantagesIndus || []).includes(label)) {
             return null;
         }
         const control = rms.controls.find(ctrl => ctrl.id === controlId);
-        return control?.name || `#${controlId}`;
+        return {
+            id: controlId,
+            name: control?.name || `#${controlId}`
+        };
     }).filter(Boolean);
-    return linked;
 }
 
 function renderBenefitFirstAssignment() {
@@ -551,20 +553,26 @@ function renderBenefitFirstAssignment() {
         <div class="benefit-first-assignment-title">Attribution guidée par avantage indu</div>
         <div class="benefit-first-assignment-grid">
             ${undueBenefits.map(label => {
-                const linkedControls = getAssignedControlNamesForBenefit(label);
+                const linkedControls = getAssignedControlsForBenefit(label);
                 const recommendedCount = getRecommendedControlIdsForBenefit(label).length;
                 const summary = linkedControls.length
-                    ? linkedControls.slice(0, 2).join(' • ') + (linkedControls.length > 2 ? ` • +${linkedControls.length - 2}` : '')
+                    ? linkedControls.slice(0, 2).map(item => item.name).join(' • ') + (linkedControls.length > 2 ? ` • +${linkedControls.length - 2}` : '')
                     : 'Aucun contrôle lié';
+                const linkedHtml = linkedControls.length
+                    ? `<div class="benefit-first-linked-controls">
+                        ${linkedControls.map(item => `<span class="benefit-first-linked-chip">#${item.id} - ${item.name}</span>`).join('')}
+                    </div>`
+                    : '';
                 return `
                     <div class="benefit-first-card">
                         <div>
                             <div class="benefit-first-label">${label}</div>
                             <div class="benefit-first-meta">${summary}</div>
+                            ${linkedHtml}
                         </div>
                         <div class="benefit-first-actions">
                             <span class="benefit-first-reco">${recommendedCount} recommandé${recommendedCount > 1 ? 's' : ''}</span>
-                            <button type="button" class="btn btn-outline" onclick="openControlSelectorForBenefit('${encodeURIComponent(label)}')">Assigner des contrôles</button>
+                            <button type="button" class="btn btn-outline" onclick="openControlSelectorForBenefit('${encodeURIComponent(label)}')">Ajouter un contrôle</button>
                         </div>
                     </div>
                 `;
@@ -1192,9 +1200,12 @@ function openControlSelector() {
 window.openControlSelector = openControlSelector;
 
 function createControlFromRisk() {
+    const benefitLabel = currentBenefitFocusForControlSelector || null;
     controlCreationContext = {
         fromRisk: true,
-        riskId: currentEditingRiskId != null ? currentEditingRiskId : null
+        riskId: currentEditingRiskId != null ? currentEditingRiskId : null,
+        benefitLabel,
+        transverse: !benefitLabel
     };
     closeControlSelector();
     if (typeof addNewControl === 'function') {
@@ -1316,6 +1327,8 @@ function toggleControlSelection(controlId) {
             }
         }
     }
+    updateSelectedControlsDisplay();
+    renderControlSelectionList();
     if (rms && typeof rms.markUnsavedChange === 'function') {
         rms.markUnsavedChange('riskForm');
     }
@@ -1332,57 +1345,20 @@ window.confirmControlSelection = confirmControlSelection;
 function updateSelectedControlsDisplay() {
     const container = document.getElementById('riskControls');
     if (!container) return;
-    if (selectedControlsForRisk.length === 0) {
-        container.innerHTML = '<div style="color: #7f8c8d; font-style: italic;">Aucun contrôle sélectionné</div>';
-        renderBenefitFirstAssignment();
-        return;
-    }
-    const undueBenefits = Array.isArray(riskBenefitsState.undue) ? riskBenefitsState.undue : [];
-    const cardsHtml = selectedControlsForRisk.map(id => {
-        const ctrl = rms.controls.find(c => c.id === id);
-        if (!ctrl) return '';
-        const name = ctrl.name || 'Sans nom';
-        const key = String(id);
-        if (!controlAssignmentsForRisk[key]) {
-            controlAssignmentsForRisk[key] = { transverse: true, avantagesIndus: [] };
-        }
-        const assignment = controlAssignmentsForRisk[key];
-        const tags = undueBenefits.length
-            ? undueBenefits.map(label => {
-                const isActive = assignment.avantagesIndus.includes(label);
-                return `<button type="button" class="control-assignment-chip ${isActive ? 'active' : ''}" onclick="toggleControlAssignmentBenefit(${id}, '${encodeURIComponent(label)}')">${label}</button>`;
-            }).join('')
-            : '<span style="font-size:0.78rem;color:#6b7280;">Ajoutez des avantages indus pour les relier aux contrôles.</span>';
-        return `
-            <div class="control-assignment-card">
-                <div class="control-assignment-header">
-                    <div class="control-assignment-title">#${id} - ${name.substring(0, 70)}${name.length > 70 ? '...' : ''}</div>
-                    <div class="control-assignment-actions">
-                        <label style="font-size:0.78rem;">
-                            <input type="checkbox" ${assignment.transverse ? 'checked' : ''} onchange="toggleControlTransverse(${id})"> Transverse
-                        </label>
-                        <button type="button" class="control-assignment-remove-btn" onclick="removeControlFromSelection(${id})" aria-label="Retirer le contrôle #${id}">
-                            Retirer
-                        </button>
-                    </div>
-                </div>
-                <div class="control-assignment-tags">${tags}</div>
-            </div>`;
-    }).join('');
     const transverseControls = selectedControlsForRisk.map(id => {
         const assignment = controlAssignmentsForRisk[String(id)];
         if (!assignment?.transverse) return null;
         const ctrl = rms.controls.find(c => c.id === id);
         if (!ctrl) return null;
-        return `<span class="transverse-control-chip">#${id} - ${ctrl.name || 'Sans nom'}</span>`;
+        return `<span class="transverse-control-chip">#${id} - ${ctrl.name || 'Sans nom'} <button type="button" class="transverse-control-remove-btn" onclick="removeControlFromSelection(${id})" aria-label="Retirer le contrôle transverse #${id}">×</button></span>`;
     }).filter(Boolean);
     const transverseSection = transverseControls.length
         ? `<div class="transverse-controls-section">
                 <div class="transverse-controls-title">Contrôles transverses</div>
                 <div class="transverse-controls-list">${transverseControls.join('')}</div>
            </div>`
-        : '';
-    container.innerHTML = `<div class="controls-assignment-list">${cardsHtml}</div>${transverseSection}`;
+        : '<div style="color: #7f8c8d; font-style: italic;">Aucun contrôle transverse sélectionné</div>';
+    container.innerHTML = transverseSection;
     renderBenefitFirstAssignment();
 }
 window.updateSelectedControlsDisplay = updateSelectedControlsDisplay;
@@ -1396,19 +1372,6 @@ function removeControlFromSelection(controlId) {
     }
 }
 window.removeControlFromSelection = removeControlFromSelection;
-
-function toggleControlTransverse(controlId) {
-    const key = String(controlId);
-    if (!controlAssignmentsForRisk[key]) {
-        controlAssignmentsForRisk[key] = { transverse: false, avantagesIndus: [] };
-    }
-    controlAssignmentsForRisk[key].transverse = !controlAssignmentsForRisk[key].transverse;
-    updateSelectedControlsDisplay();
-    if (rms && typeof rms.markUnsavedChange === 'function') {
-        rms.markUnsavedChange('riskForm');
-    }
-}
-window.toggleControlTransverse = toggleControlTransverse;
 
 function toggleControlAssignmentBenefit(controlId, encodedLabel) {
     const label = decodeURIComponent(encodedLabel);


### PR DESCRIPTION
### Motivation
- Provide a clearer UX for adding global (transverse) controls and linking controls to specific "avantages indus" (undue benefits). 
- Persist control assignment context when creating controls from the risk editor so newly created controls can be auto-assigned to the current risk and/or benefit focus. 
- Ship small UI text and build version updates for the release.

### Description
- Bumped app version text and footer to `v2.14.37` in `CartoModel.html` and adjusted the control button/help copy to clarify adding transverse controls. 
- Persist control assignment context during control creation in `assets/js/rms.integrations.js` by populating `window.controlAssignmentsForRisk` with `transverse` and `avantagesIndus` for the new control. 
- Reworked selection and assignment UI logic in `assets/js/rms.ui.js` including `getAssignedControlsForBenefit`, `createControlFromRisk`, `toggleControlSelection`, `updateSelectedControlsDisplay`, `renderBenefitFirstAssignment`, and related helpers to support benefit-focused workflows and to render transverse controls as removable chips. 
- Removed the old `toggleControlTransverse` checkbox flow and replaced it with the new chip/assignment pattern and remove action. 
- Added CSS rules in `assets/css/main.css` for transverse control chips, remove buttons, and linked-control chips (`.transverse-control-chip`, `.transverse-control-remove-btn`, `.benefit-first-linked-chip`, etc.).

### Testing
- Ran frontend linting with `npm run lint` and a production build with `npm run build`, both completed successfully.
- No new automated unit tests were added as part of this change and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f5135b6c832e94515f787b9c4ea2)