### PR TITLE
Add requested control items to mindmap questionnaire and bump app version to 2.14.38

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.37</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.38</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.37</span>
+            <span class="app-version">Version 2.14.38</span>
         </footer>
     </div>
 

--- a/mindmap/script.js
+++ b/mindmap/script.js
@@ -248,10 +248,25 @@ Exemples:
       },
       'lfb-controleur': {
         controle: `**Quels sont les principaux mécanismes de prévention ou de contrôle que vous avez mis en place pour prévenir et détecter les risques de corruption sur les opérations ?**
-- Quelles validations existent avant un engagement ?
-- Quels contrôles existent sur les flux financiers ?
-- Y-a-t-il des séparations de tâches prévues pour éviter les prises de décisions isolées ?
-- Formation ?`,
+- Separation of medical and commercial roles
+- Segregation of duties
+- Collegial decision-making
+- Collegiality via committees/review bodies
+- Documentation of needs
+- Documentation of partner selection
+- Due diligence
+- Pricing structure / ceiling
+- Competitive tendering
+- Level 2 prior authorisation
+- Level 2 ex-post control
+- Reconciliation of invoice and purchase order
+- Proof of service rendered
+- Traceability of actions/flows
+- Traceability of the validation workflow
+- Contract with anti-corruption clause
+- Contract without anti-corruption clause
+- Anti-corruption training
+- Internal whistleblowing mechanism`,
         description: `**Pouvez-vous me décrire ce contrôle et la façon dont il est mis en œuvre ?**
 - Qui est responsable du contrôle ?
 - À quel moment intervient-il dans le processus ?
@@ -514,10 +529,25 @@ Examples:
       },
       'lfb-controleur': {
         controle: `**What are the main prevention or control mechanisms you have put in place to prevent and detect corruption risks in operations?**
-- What validations exist before a commitment?
-- What controls exist on financial flows?
-- Are there segregation-of-duties arrangements to avoid isolated decision-making?
-- Trainings?`,
+- Separation of medical and commercial roles
+- Segregation of duties
+- Collegial decision-making
+- Collegiality via committees/review bodies
+- Documentation of needs
+- Documentation of partner selection
+- Due diligence
+- Pricing structure / ceiling
+- Competitive tendering
+- Level 2 prior authorisation
+- Level 2 ex-post control
+- Reconciliation of invoice and purchase order
+- Proof of service rendered
+- Traceability of actions/flows
+- Traceability of the validation workflow
+- Contract with anti-corruption clause
+- Contract without anti-corruption clause
+- Anti-corruption training
+- Internal whistleblowing mechanism`,
         description: `**Can you describe this control and how it is implemented?**
 - Who is responsible for the control?
 - When does it take place in the process?


### PR DESCRIPTION
### Motivation
- Enrich the existing controls catalogue used in the "Contrôles" questionnaire so the tool lists the requested control items for assessment and harmonise both French and English variants. 
- Bump the visible app version metadata in the page title and footer to reflect the content update as required by repository conventions.

### Description
- Added the 19 requested control items to the `controle` question for the `lfb-controleur` template in `mindmap/script.js` (French and English entries). 
- Updated the application page title and footer version string in `CartoModel.html` from `2.14.37` to `2.14.38`.
- Changes are limited to questionnaire text and UI metadata (no behavioral logic changes). 
- New visible version number: `2.14.38`.

### Testing
- Ran `git diff --check` which reported no whitespace or formatting errors and succeeded. 
- Verified working tree status with `git status --short` and inspected modified files `mindmap/script.js` and `CartoModel.html` to confirm expected edits. 
- No automated browser UI tests were available in this environment; textual/format checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ffce0254832ebf123bdbb82dc016)