### PR TITLE
Support per-benefit control assignment and selection fix; bump version to 2.14.39

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.38</span>
+            <span class="app-version">Version 2.14.39</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1250,7 +1250,11 @@ function renderControlSelectionList() {
         ? availableControls.filter(ctrl => !recommendedSet.has(ctrl.id))
         : availableControls;
     const renderControlItem = ctrl => {
-        const isSelected = selectedControlsForRisk.includes(ctrl.id);
+        const key = String(ctrl.id);
+        const assignment = controlAssignmentsForRisk[key] || {};
+        const isSelected = focusLabel
+            ? (assignment.avantagesIndus || []).includes(focusLabel)
+            : selectedControlsForRisk.includes(ctrl.id);
         const typeKey = ctrl?.type != null ? String(ctrl.type).toLowerCase() : '';
         const typeLabel = typeKey ? (typeMap[typeKey] || ctrl.type || '') : '';
         const originKey = ctrl?.origin != null ? String(ctrl.origin).toLowerCase() : '';
@@ -1302,21 +1306,38 @@ window.closeControlSelector = closeControlSelector;
 function toggleControlSelection(controlId) {
     const index = selectedControlsForRisk.indexOf(controlId);
     const key = String(controlId);
-    if (index > -1) {
+    const focusedBenefit = currentBenefitFocusForControlSelector;
+
+    if (focusedBenefit) {
+        if (index === -1) {
+            selectedControlsForRisk.push(controlId);
+        }
+
+        if (!controlAssignmentsForRisk[key]) {
+            controlAssignmentsForRisk[key] = { transverse: false, avantagesIndus: [] };
+        }
+
+        const entry = controlAssignmentsForRisk[key];
+        entry.avantagesIndus = Array.isArray(entry.avantagesIndus) ? entry.avantagesIndus : [];
+        const hasFocusedBenefit = entry.avantagesIndus.includes(focusedBenefit);
+
+        if (hasFocusedBenefit) {
+            entry.avantagesIndus = entry.avantagesIndus.filter(label => label !== focusedBenefit);
+            if (!entry.transverse && entry.avantagesIndus.length === 0) {
+                selectedControlsForRisk = selectedControlsForRisk.filter(id => id !== controlId);
+                delete controlAssignmentsForRisk[key];
+            }
+        } else {
+            entry.avantagesIndus.push(focusedBenefit);
+            entry.transverse = false;
+        }
+    } else if (index > -1) {
         selectedControlsForRisk.splice(index, 1);
         delete controlAssignmentsForRisk[key];
     } else {
         selectedControlsForRisk.push(controlId);
         if (!controlAssignmentsForRisk[key]) {
             controlAssignmentsForRisk[key] = { transverse: true, avantagesIndus: [] };
-        }
-        if (currentBenefitFocusForControlSelector) {
-            const entry = controlAssignmentsForRisk[key];
-            entry.transverse = false;
-            entry.avantagesIndus = Array.isArray(entry.avantagesIndus) ? entry.avantagesIndus : [];
-            if (!entry.avantagesIndus.includes(currentBenefitFocusForControlSelector)) {
-                entry.avantagesIndus.push(currentBenefitFocusForControlSelector);
-            }
         }
     }
     updateSelectedControlsDisplay();


### PR DESCRIPTION
### Motivation
- Introduce per-benefit assignment for controls so a control can be marked as transverse or assigned to specific `avantagesIndus` (benefits) when selecting controls for a risk. 
- Ensure the control selection UI correctly reflects assignments when a benefit-focused selection is active. 
- Bump the app version displayed in the HTML to mark the change.

### Description
- Bumped the app version string in `CartoModel.html` from `Version 2.14.38` to `Version 2.14.39`.
- In `assets/js/rms.ui.js`, updated `renderControlSelectionList()` to compute the checkbox checked state from `controlAssignmentsForRisk` when a `focusLabel` is present by deriving a `key` and `assignment` per control.
- Reworked `toggleControlSelection()` to support focused-benefit behavior via `currentBenefitFocusForControlSelector`: when a benefit is focused it toggles the benefit inside `controlAssignmentsForRisk[key].avantagesIndus`, ensures the control is kept in `selectedControlsForRisk` while any assignment exists, and removes the control and its assignment when no assignments remain; when no benefit is focused it preserves the previous toggle behavior and marks new assignments as `transverse: true`.
- Kept UI refresh calls (`updateSelectedControlsDisplay()` and `renderControlSelectionList()`) and unsaved-change marking intact after changes.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1066839ac832e89af213545b14dbf)