### PR TITLE
Retirer le compteur "recommandé" dans l’attribution des contrôles

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.39</span>
+            <span class="app-version">Version 2.14.40</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -554,7 +554,6 @@ function renderBenefitFirstAssignment() {
         <div class="benefit-first-assignment-grid">
             ${undueBenefits.map(label => {
                 const linkedControls = getAssignedControlsForBenefit(label);
-                const recommendedCount = getRecommendedControlIdsForBenefit(label).length;
                 const summary = linkedControls.length
                     ? linkedControls.slice(0, 2).map(item => item.name).join(' • ') + (linkedControls.length > 2 ? ` • +${linkedControls.length - 2}` : '')
                     : 'Aucun contrôle lié';
@@ -571,7 +570,6 @@ function renderBenefitFirstAssignment() {
                             ${linkedHtml}
                         </div>
                         <div class="benefit-first-actions">
-                            <span class="benefit-first-reco">${recommendedCount} recommandé${recommendedCount > 1 ? 's' : ''}</span>
                             <button type="button" class="btn btn-outline" onclick="openControlSelectorForBenefit('${encodeURIComponent(label)}')">Ajouter un contrôle</button>
                         </div>
                     </div>


### PR DESCRIPTION
### Motivation
- Supprimer l'affichage du compteur "X recommandé" à côté des avantages indus dans la zone « Attribution guidée par avantage indu » pour simplifier l'interface et mettre à jour la version affichée dans le footer vers `2.14.40`.

### Description
- Supprimé le calcul et le rendu de `recommendedCount` dans `renderBenefitFirstAssignment` de `assets/js/rms.ui.js`, et mis à jour la chaîne de version dans `CartoModel.html` de `Version 2.14.39` à `Version 2.14.40` (fichiers modifiés : `assets/js/rms.ui.js`, `CartoModel.html`).

### Testing
- Exécuté `git diff --check` qui n'a retourné aucun problème et les modifications ont été commitées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e10dea5df0832eab9b2b09afb865a8)