### PR TITLE
Add requested generic controls to default data and bump app version to 2.14.41

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.38</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.41</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.40</span>
+            <span class="app-version">Version 2.14.41</span>
         </footer>
     </div>
 

--- a/assets/js/rms.data.records.js
+++ b/assets/js/rms.data.records.js
@@ -1,7 +1,27 @@
 (function (global) {
     const defaultDataSets = {
         risks: [],
-        controls: [],
+        controls: [
+            { id: 1, name: 'Separation of medical and commercial roles (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'annuelle', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 2, name: 'Segregation of duties (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'annuelle', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 3, name: 'Collegial decision-making (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 4, name: 'Collegiality via committees/review bodies (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 5, name: 'Documentation of needs (generic)', type: 'a-priori', origin: 'interne', owner: 'Achats', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 6, name: 'Documentation of partner selection (generic)', type: 'a-priori', origin: 'interne', owner: 'Achats', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 7, name: 'Due diligence (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 8, name: 'Pricing structure / ceiling (generic)', type: 'a-priori', origin: 'interne', owner: 'Finance', frequency: 'annuelle', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 9, name: 'Competitive tendering (generic)', type: 'a-priori', origin: 'interne', owner: 'Achats', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 10, name: 'Level 2 prior authorisation (generic)', type: 'a-priori', origin: 'interne', owner: 'Management', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 11, name: 'Level 2 ex-post control (generic)', type: 'a-posteriori', origin: 'interne', owner: 'Contrôle interne', frequency: 'mensuelle', mode: 'picking', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 12, name: 'Reconciliation of invoice and purchase order (generic)', type: 'a-posteriori', origin: 'interne', owner: 'Finance', frequency: 'mensuelle', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 13, name: 'Proof of service rendered (generic)', type: 'a-posteriori', origin: 'interne', owner: 'Achats', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 14, name: 'Traceability of actions/flows (generic)', type: 'a-posteriori', origin: 'interne', owner: 'IT', frequency: 'quotidienne', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 15, name: 'Traceability of the validation workflow (generic)', type: 'a-posteriori', origin: 'interne', owner: 'IT', frequency: 'quotidienne', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 16, name: 'Contract with anti-corruption clause (generic)', type: 'a-priori', origin: 'interne', owner: 'Juridique', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'forte', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 17, name: 'Contract without anti-corruption clause (generic)', type: 'a-posteriori', origin: 'interne', owner: 'Juridique', frequency: 'ad-hoc', mode: 'picking', effectiveness: 'faible', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 18, name: 'Anti-corruption training (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'annuelle', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
+            { id: 19, name: 'Internal whistleblowing mechanism (generic)', type: 'a-posteriori', origin: 'interne', owner: 'Compliance', frequency: 'ad-hoc', mode: 'systematique', effectiveness: 'moyenne', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' }
+        ],
         actionPlans: [],
         interviews: [],
         history: [


### PR DESCRIPTION
### Motivation
- Pré-populer le référentiel « Contrôles & Mesures » avec les contrôles génériques demandés pour faciliter leur réutilisation dans l'application.
- Respecter la consigne de versioning en mettant à jour le numéro d'application affiché dans le footer pour chaque tâche.

### Description
- Ajout de 19 contrôles génériques dans le jeu de données par défaut `RMS_DEFAULT_DATA.controls` avec métadonnées cohérentes (`type`, `origin`, `owner`, `frequency`, `mode`, `effectiveness`, `status`, `dateCreation`) afin qu'ils apparaissent comme contrôles actifs utilisables (fichier modifié : `assets/js/rms.data.records.js`).
- Mise à jour du titre de la page et du footer pour refléter la nouvelle version de l'application `Version 2.14.41` (fichier modifié : `CartoModel.html`).
- Les contrôles ajoutés portent des noms fournis (ex. `Separation of medical and commercial roles (generic)`, `Due diligence (generic)`, etc.) et une date de création `2026-04-16`.

### Testing
- `git diff --check` exécuté pour valider l'absence d'espaces/trous de formatage et réussi.
- Vérification de syntaxe JS via `node -e "new Function(require('fs').readFileSync('assets/js/rms.data.records.js','utf8'))"` et la commande a confirmé que `assets/js/rms.data.records.js` est syntaxiquement valide.
- L'interface locale n'a pas été testée visuellement ici; les données sont seedées dans le jeu par défaut et seront chargées si le stockage local n'écrase pas ces valeurs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1117c8398832ea59e50695540ee93)