### PR TITLE
Fix control selection logic and bump app version to 2.14.42

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.41</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.42</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.41</span>
+            <span class="app-version">Version 2.14.42</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1252,7 +1252,7 @@ function renderControlSelectionList() {
         const assignment = controlAssignmentsForRisk[key] || {};
         const isSelected = focusLabel
             ? (assignment.avantagesIndus || []).includes(focusLabel)
-            : selectedControlsForRisk.includes(ctrl.id);
+            : !!assignment.transverse;
         const typeKey = ctrl?.type != null ? String(ctrl.type).toLowerCase() : '';
         const typeLabel = typeKey ? (typeMap[typeKey] || ctrl.type || '') : '';
         const originKey = ctrl?.origin != null ? String(ctrl.origin).toLowerCase() : '';


### PR DESCRIPTION
### Motivation
- Ensure the control selection checkboxes reflect the actual assignment state by using the `assignment.transverse` flag when not filtering by a focus label.
- Increment the application version to `2.14.42` in the UI to reflect the patch.

### Description
- Change `renderControlSelectionList` in `assets/js/rms.ui.js` so that `isSelected` is `!!assignment.transverse` when `focusLabel` is not set, replacing the previous `selectedControlsForRisk.includes(ctrl.id)` check.
- Update the HTML title and footer version strings in `CartoModel.html` from `2.14.41` to `2.14.42`.

### Testing
- Ran `npm run lint` which passed without errors.
- Ran unit tests with `npm test` which completed successfully.
- Performed a production build with `npm run build` which succeeded and produced the expected artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2357db1d0832ea89e197f2d05a9bd)