### PR TITLE
Country chips UI redesign, selection syncing, and version bump to 2.14.43

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.42</title>
+    <title>Cartographie des Risques Corruption - Sapin 2 v2.14.43</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Gestion des dépendances locales avec repli CDN -->
     <script>
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.42</span>
+            <span class="app-version">Version 2.14.43</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1080,31 +1080,48 @@ body.feedback-mode-paused .feedback-panel * {
 
 .risk-country-options {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: nowrap;
     gap: 8px;
-    max-height: 220px;
-    overflow-y: auto;
-    padding-right: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 2px 4px 6px 2px;
+    scrollbar-width: thin;
 }
 
 .risk-country-option {
     display: flex;
     align-items: center;
-    gap: 8px;
+    justify-content: center;
+    gap: 0;
     font-size: 0.95rem;
-    color: var(--text-color);
-    padding: 4px 6px;
-    border-radius: 8px;
-    transition: background 0.15s ease;
+    font-weight: 600;
+    white-space: nowrap;
+    color: color-mix(in srgb, var(--country-column-color, #2563eb) 70%, #0f172a 30%);
+    background: color-mix(in srgb, var(--country-column-color, #2563eb) 16%, #ffffff 84%);
+    border: 1px solid color-mix(in srgb, var(--country-column-color, #2563eb) 36%, #ffffff 64%);
+    padding: 8px 12px;
+    border-radius: 999px;
+    transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+    cursor: pointer;
+    flex: 0 0 auto;
 }
 
 .risk-country-option:hover {
-    background: rgba(11, 61, 96, 0.08);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.12);
+}
+
+.risk-country-option.is-selected {
+    color: #ffffff;
+    background: var(--country-column-color, #2563eb);
+    border-color: color-mix(in srgb, var(--country-column-color, #2563eb) 75%, #0f172a 25%);
 }
 
 .risk-country-option input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
 }
 
 .risk-country-empty {

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -1732,7 +1732,7 @@ class RiskManagementSystem {
         this.registerMindMapLinkListeners(workspaceWrapper);
 
         const columns = this.getMindMapColumns();
-        columns.forEach(column => {
+        columns.forEach((column, index) => {
             const columnElement = document.createElement('div');
             columnElement.className = 'mindmap-column';
             columnElement.dataset.column = column.key;
@@ -3237,7 +3237,25 @@ class RiskManagementSystem {
 
         const assignedValues = new Set();
 
-        const createColumnCard = (column, entries, { highlight } = {}) => {
+        const chipPalette = [
+            '#2563eb',
+            '#7c3aed',
+            '#db2777',
+            '#ea580c',
+            '#16a34a',
+            '#0891b2',
+            '#be123c',
+            '#4f46e5'
+        ];
+
+        const resolveColumnColor = (column, index) => {
+            if (column && typeof column.color === 'string' && column.color.trim()) {
+                return column.color.trim();
+            }
+            return chipPalette[index % chipPalette.length];
+        };
+
+        const createColumnCard = (column, entries, columnIndex, { highlight } = {}) => {
             const card = document.createElement('article');
             card.className = 'risk-country-column';
             if (highlight) {
@@ -3246,6 +3264,8 @@ class RiskManagementSystem {
             if (column?.key) {
                 card.dataset.columnKey = column.key;
             }
+            const columnColor = resolveColumnColor(column, columnIndex);
+            card.style.setProperty('--country-column-color', columnColor);
 
             const header = document.createElement('div');
             header.className = 'risk-country-column-header';
@@ -3295,6 +3315,10 @@ class RiskManagementSystem {
                 entries.forEach(entry => {
                     const optionLabel = document.createElement('label');
                     optionLabel.className = 'risk-country-option';
+                    optionLabel.dataset.countryValue = entry.value;
+                    if (selectedValues.has(entry.value)) {
+                        optionLabel.classList.add('is-selected');
+                    }
 
                     const checkbox = document.createElement('input');
                     checkbox.type = 'checkbox';
@@ -3330,7 +3354,7 @@ class RiskManagementSystem {
             container.appendChild(card);
         };
 
-        columns.forEach(column => {
+        columns.forEach((column, index) => {
             if (!column || typeof column !== 'object') {
                 return;
             }
@@ -3339,13 +3363,13 @@ class RiskManagementSystem {
                 .map(value => ({ value, label: labelMap.get(value) || value }))
                 .filter(entry => entry.label);
             entries.forEach(entry => assignedValues.add(entry.value));
-            createColumnCard(column, entries);
+            createColumnCard(column, entries, index);
         });
 
         const unassigned = options.filter(option => !assignedValues.has(option.value));
         if (unassigned.length) {
             const column = { key: 'unassigned', label: 'Entités non attribuées' };
-            createColumnCard(column, unassigned, { highlight: true });
+            createColumnCard(column, unassigned, columns.length, { highlight: true });
         }
 
         if (!container.children.length) {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -758,7 +758,12 @@ function syncRiskCountryCheckboxesFromSelect() {
     const checkboxes = document.querySelectorAll('.risk-country-checkbox[data-country-value]');
     checkboxes.forEach(checkbox => {
         const value = checkbox.dataset.countryValue || checkbox.value;
-        checkbox.checked = selectedValues.has(value);
+        const isSelected = selectedValues.has(value);
+        checkbox.checked = isSelected;
+        const chip = checkbox.closest('.risk-country-option');
+        if (chip) {
+            chip.classList.toggle('is-selected', isSelected);
+        }
     });
 }
 window.syncRiskCountryCheckboxesFromSelect = syncRiskCountryCheckboxesFromSelect;


### PR DESCRIPTION
### Motivation
- Modernize the presentation of configured entities in country columns by turning long vertical lists into compact horizontal chips that better surface color and selection state.
- Ensure visual selection state stays synchronized with the underlying `<select>` and checkboxes.
- Bump the app version to `2.14.43`.

### Description
- Updated HTML version strings in `CartoModel.html` to `Sapin 2 v2.14.43` and footer `Version 2.14.43`.
- Redesigned country option UI in `assets/css/main.css` to a horizontal, chip-like layout with rounded pills, hover elevation, selected styling (`.is-selected`), hidden native checkbox and improved paddings and scrollbar behavior.
- In `assets/js/rms.core.js` added a `chipPalette` and `resolveColumnColor` to assign per-column colors, set a `--country-column-color` CSS variable on column cards, and annotated option labels with `data-country-value`; updated `createColumnCard` signature and calls to accept a column index and to mark chips initially selected.
- In `assets/js/rms.ui.js` updated `syncRiskCountryCheckboxesFromSelect()` to toggle the `.is-selected` class on chip elements when checkbox/select state changes; kept `applyRiskCountryCheckboxState()` behavior intact.
- Minor iteration signature change for mindmap columns loop to expose the index (no behavioral change for mindmap rendering).

### Testing
- Ran `npm run build` to build assets and bundle changes, which completed successfully.
- Ran `npm run lint` to validate style rules, which passed with no new issues.
- Ran `npm test` (unit tests) and UI sync-related tests, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23961c8b8832ead068971a522a8e7)