### PR TITLE
Add chip-based multi-select UI for risk form selects (processus, sous-processus, type, tiers)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -745,7 +745,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.43</span>
+            <span class="app-version">Version 2.14.45</span>
         </footer>
     </div>
 
@@ -1167,14 +1167,16 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label class="form-label required">Processus</label>
-                                <select class="form-select" id="processus" required multiple size="5" onchange="rms.updateSousProcessusOptions()">
+                                <select class="form-select visually-hidden" id="processus" required multiple size="5" onchange="rms.updateSousProcessusOptions()" aria-hidden="true" tabindex="-1">
                                 </select>
+                                <div id="processusChips" class="risk-multi-chip-list" aria-label="Processus sélectionnables"></div>
                                 <div class="form-helper">Vous pouvez sélectionner plusieurs processus.</div>
                             </div>
                             <div class="form-group">
                                 <label class="form-label">Sous-processus</label>
-                                <select class="form-select" id="sousProcessus" multiple size="5">
+                                <select class="form-select visually-hidden" id="sousProcessus" multiple size="5" aria-hidden="true" tabindex="-1">
                                 </select>
+                                <div id="sousProcessusChips" class="risk-multi-chip-list" aria-label="Sous-processus sélectionnables"></div>
                                 <div class="form-helper">Les sous-processus affichés dépendent des processus choisis.</div>
                             </div>
                         </div>
@@ -1182,8 +1184,9 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label class="form-label required">Type de Corruption</label>
-                                <select class="form-select" id="typeCorruption" required multiple size="5">
+                                <select class="form-select visually-hidden" id="typeCorruption" required multiple size="5" aria-hidden="true" tabindex="-1">
                                 </select>
+                                <div id="typeCorruptionChips" class="risk-multi-chip-list" aria-label="Types de corruption sélectionnables"></div>
                                 <div class="form-helper">Sélection multiple possible.</div>
                             </div>
                             <div class="form-group">
@@ -1197,8 +1200,9 @@
                         <div class="form-grid">
                             <div class="form-group" style="grid-column: 1 / -1;">
                                 <label class="form-label">Tiers concernés</label>
-                                <select class="form-select" id="tiers" multiple size="5">
+                                <select class="form-select visually-hidden" id="tiers" multiple size="5" aria-hidden="true" tabindex="-1">
                                 </select>
+                                <div id="tiersChips" class="risk-multi-chip-list" aria-label="Tiers concernés sélectionnables"></div>
                             </div>
                         </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1131,6 +1131,47 @@ body.feedback-mode-paused .feedback-panel * {
     padding: 6px 2px;
 }
 
+.risk-multi-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.risk-multi-chip-option {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    font-size: 0.9rem;
+    font-weight: 600;
+    white-space: nowrap;
+    color: color-mix(in srgb, var(--risk-chip-color, #2563eb) 70%, #0f172a 30%);
+    background: color-mix(in srgb, var(--risk-chip-color, #2563eb) 14%, #ffffff 86%);
+    border: 1px solid color-mix(in srgb, var(--risk-chip-color, #2563eb) 34%, #ffffff 66%);
+    padding: 7px 12px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.risk-multi-chip-option:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.12);
+}
+
+.risk-multi-chip-option.is-selected {
+    color: #ffffff;
+    background: var(--risk-chip-color, #2563eb);
+    border-color: color-mix(in srgb, var(--risk-chip-color, #2563eb) 72%, #0f172a 28%);
+}
+
+.risk-multi-chip-option input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
 .risk-matrix-editor {
     display: flex;
     flex-direction: column;

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -2769,6 +2769,9 @@ class RiskManagementSystem {
                 opt.selected = targetValues.includes(opt.value);
             });
         }
+        if (typeof renderAllRiskMultiSelectChips === 'function') {
+            renderAllRiskMultiSelectChips();
+        }
         this.renderRiskCountryColumns();
         this.renderMatrixEntityFilterChips();
         fill('controlType', this.config.controlTypes, 'Sélectionner...');
@@ -6523,6 +6526,9 @@ class RiskManagementSystem {
                 sousSelect.appendChild(opt);
             });
         });
+        if (typeof renderRiskMultiSelectChips === 'function') {
+            renderRiskMultiSelectChips('sousProcessus');
+        }
     }
 
     getInterviewFilePath(fileName) {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -884,6 +884,182 @@ function deselectAllRiskCountries() {
 }
 window.deselectAllRiskCountries = deselectAllRiskCountries;
 
+const RISK_MULTI_SELECT_CHIP_CONFIG = {
+    processus: { containerId: 'processusChips', defaultColor: '#2563eb' },
+    sousProcessus: { containerId: 'sousProcessusChips', defaultColor: '#2563eb' },
+    typeCorruption: { containerId: 'typeCorruptionChips', defaultColor: '#db2777' },
+    tiers: { containerId: 'tiersChips', defaultColor: '#16a34a' }
+};
+
+function getRiskMultiSelectConfig(selectId) {
+    return RISK_MULTI_SELECT_CHIP_CONFIG[selectId] || null;
+}
+
+const RISK_PROCESS_CHIP_PALETTE = [
+    '#2563eb',
+    '#7c3aed',
+    '#db2777',
+    '#ea580c',
+    '#16a34a',
+    '#0891b2',
+    '#be123c',
+    '#4f46e5'
+];
+
+function buildRiskProcessChipColorMap() {
+    const map = new Map();
+    const processSelect = document.getElementById('processus');
+    if (!processSelect) {
+        return map;
+    }
+
+    Array.from(processSelect.options).forEach((option, index) => {
+        map.set(option.value, RISK_PROCESS_CHIP_PALETTE[index % RISK_PROCESS_CHIP_PALETTE.length]);
+    });
+
+    return map;
+}
+
+function resolveParentProcessForSubProcess(subProcessValue) {
+    if (!subProcessValue || !window.rms || !rms.config || !rms.config.subProcesses) {
+        return '';
+    }
+
+    const entries = Object.entries(rms.config.subProcesses);
+    for (const [processValue, subProcesses] of entries) {
+        if (!Array.isArray(subProcesses)) {
+            continue;
+        }
+        const match = subProcesses.some(item => item && item.value === subProcessValue);
+        if (match) {
+            return processValue;
+        }
+    }
+
+    return '';
+}
+
+function resolveRiskMultiChipColor(selectId, optionValue, processColorMap) {
+    const config = getRiskMultiSelectConfig(selectId);
+    const defaultColor = config?.defaultColor || '#2563eb';
+
+    if (selectId === 'processus') {
+        return processColorMap.get(optionValue) || defaultColor;
+    }
+
+    if (selectId === 'sousProcessus') {
+        const parentProcess = resolveParentProcessForSubProcess(optionValue);
+        return processColorMap.get(parentProcess) || defaultColor;
+    }
+
+    return defaultColor;
+}
+
+function applyRiskMultiSelectValue(selectId, value, isSelected) {
+    const select = document.getElementById(selectId);
+    if (!select) {
+        return;
+    }
+    const option = Array.from(select.options).find(opt => opt.value === value);
+    if (!option) {
+        return;
+    }
+    option.selected = !!isSelected;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+function syncRiskMultiSelectChipsFromSelect(selectId) {
+    const config = getRiskMultiSelectConfig(selectId);
+    const select = document.getElementById(selectId);
+    if (!config || !select) {
+        return;
+    }
+
+    const container = document.getElementById(config.containerId);
+    if (!container) {
+        return;
+    }
+
+    const selectedValues = new Set(Array.from(select.selectedOptions).map(option => option.value));
+    const checkboxes = container.querySelectorAll('input[type="checkbox"][data-risk-multi-value]');
+    checkboxes.forEach(checkbox => {
+        const value = checkbox.dataset.riskMultiValue || checkbox.value;
+        const isSelected = selectedValues.has(value);
+        checkbox.checked = isSelected;
+        const chip = checkbox.closest('.risk-multi-chip-option');
+        if (chip) {
+            chip.classList.toggle('is-selected', isSelected);
+        }
+    });
+}
+window.syncRiskMultiSelectChipsFromSelect = syncRiskMultiSelectChipsFromSelect;
+
+function renderRiskMultiSelectChips(selectId) {
+    const config = getRiskMultiSelectConfig(selectId);
+    const select = document.getElementById(selectId);
+    if (!config || !select) {
+        return;
+    }
+
+    const container = document.getElementById(config.containerId);
+    if (!container) {
+        return;
+    }
+
+    const selectedValues = new Set(Array.from(select.selectedOptions).map(option => option.value));
+    const options = Array.from(select.options).map(option => ({
+        value: option.value,
+        label: option.textContent || option.value
+    }));
+
+    container.innerHTML = '';
+    const processColorMap = buildRiskProcessChipColorMap();
+
+    options.forEach(entry => {
+        const optionLabel = document.createElement('label');
+        optionLabel.className = 'risk-multi-chip-option';
+        optionLabel.dataset.riskMultiValue = entry.value;
+        optionLabel.style.setProperty('--risk-chip-color', resolveRiskMultiChipColor(selectId, entry.value, processColorMap));
+        if (selectedValues.has(entry.value)) {
+            optionLabel.classList.add('is-selected');
+        }
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.value = entry.value;
+        checkbox.dataset.riskMultiValue = entry.value;
+        checkbox.checked = selectedValues.has(entry.value);
+        checkbox.addEventListener('change', () => {
+            applyRiskMultiSelectValue(selectId, entry.value, checkbox.checked);
+            syncRiskMultiSelectChipsFromSelect(selectId);
+        });
+        optionLabel.appendChild(checkbox);
+
+        const text = document.createElement('span');
+        text.textContent = entry.label;
+        optionLabel.appendChild(text);
+
+        container.appendChild(optionLabel);
+    });
+
+    if (!select.dataset.riskMultiSyncAttached) {
+        select.addEventListener('change', () => {
+            syncRiskMultiSelectChipsFromSelect(selectId);
+        });
+        select.dataset.riskMultiSyncAttached = 'true';
+    }
+
+    syncRiskMultiSelectChipsFromSelect(selectId);
+}
+window.renderRiskMultiSelectChips = renderRiskMultiSelectChips;
+
+function renderAllRiskMultiSelectChips() {
+    Object.keys(RISK_MULTI_SELECT_CHIP_CONFIG).forEach(selectId => {
+        renderRiskMultiSelectChips(selectId);
+    });
+}
+window.renderAllRiskMultiSelectChips = renderAllRiskMultiSelectChips;
+
 function addNewRisk() {
     currentEditingRiskId = null;
     const form = document.getElementById('riskForm');
@@ -896,11 +1072,7 @@ function addNewRisk() {
             rms.updateSousProcessusOptions();
             setSelectedValues('sousProcessus', lastRiskData.sousProcessusAssocies || (lastRiskData.sousProcessus ? [lastRiskData.sousProcessus] : []));
             setSelectedValues('typeCorruption', lastRiskData.typesCorruption || (lastRiskData.typeCorruption ? [lastRiskData.typeCorruption] : []));
-
-            const tiersSelect = document.getElementById('tiers');
-            Array.from(tiersSelect.options).forEach(opt => {
-                opt.selected = lastRiskData.tiers?.includes(opt.value);
-            });
+            setSelectedValues('tiers', lastRiskData.tiers || []);
 
             setRiskCountriesSelection(lastRiskData.paysExposes || []);
 
@@ -954,6 +1126,7 @@ function addNewRisk() {
                 impactNetInput.value = impactNetInput.value || 1;
             }
         }
+        renderAllRiskMultiSelectChips();
 
         if (statutSelect) {
             const defaultStatus = rms?.config?.riskStatuses?.[0]?.value || '';


### PR DESCRIPTION
### Motivation
- Improve usability of multi-select fields in the risk creation/edit form by replacing large native selects with compact, clickable chips. 
- Provide visual association and color-coding for processes and their sub-processes to make selections clearer. 
- Keep original form semantics intact by syncing chip state with underlying `<select>` elements for compatibility with existing form handling.

### Description
- HTML: hide native multi-selects (`processus`, `sousProcessus`, `typeCorruption`, `tiers`) with `visually-hidden` and add chip container elements like `processusChips`, `sousProcessusChips`, `typeCorruptionChips`, and `tiersChips`, and bump app version to `2.14.45` in `CartoModel.html`.
- CSS: add styles for `.risk-multi-chip-list` and `.risk-multi-chip-option` to render chips, hover/selected states and color variables in `assets/css/main.css`.
- JS: implement chip rendering, synchronization and interaction helpers in `assets/js/rms.ui.js`, including `renderRiskMultiSelectChips`, `renderAllRiskMultiSelectChips`, `syncRiskMultiSelectChipsFromSelect`, `applyRiskMultiSelectValue`, color palette mapping, and helpers to resolve parent processes for sub-process color resolution; expose necessary functions on `window` for integration.
- Integration: call `renderAllRiskMultiSelectChips()` on init in `rms.core.js` and after `updateSousProcessusOptions()`, and call `renderAllRiskMultiSelectChips()` when opening the risk form; replace the previous direct DOM selection logic for `tiers` with `setSelectedValues('tiers', ...)` to reuse existing selection helpers.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23d012ae0832e85ebc31b1eebfffa)