### PR TITLE
feat: add Quick assessment tab with scenario loader and fast scoring

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -143,6 +143,9 @@
                 <button class="tab" onclick="switchTab('interviews')">
                     🗣️ Interviews
                 </button>
+                <button class="tab" onclick="switchTab('quick-assessment')">
+                    ⚡ Quick assessment
+                </button>
                 <button class="tab" onclick="switchTab('matrix')">
                     📈 Risk Matrix
                 </button>
@@ -353,6 +356,86 @@
                         <div class="interview-loading-text">Loading interview reports...</div>
                     </div>
                     <div id="interviewList" class="interview-list"></div>
+                </div>
+            </div>
+        </div>
+
+        <div id="quick-assessment-tab" class="tab-content">
+            <div class="main-content">
+                <div class="toolbar">
+                    <div class="toolbar-title" id="qaToolbarTitle">Quick assessment</div>
+                    <div class="toolbar-actions">
+                        <button class="btn btn-outline" type="button" id="qaExportJsonBtn">Export JSON</button>
+                        <button class="btn btn-outline" type="button" id="qaExportCsvBtn">Export CSV</button>
+                        <button class="btn btn-secondary" type="button" id="qaImportBtn">Import JSON</button>
+                        <input type="file" id="qaImportFile" accept="application/json" hidden>
+                    </div>
+                </div>
+                <div class="content-area quick-assessment-content">
+                    <div class="qa-subtabs">
+                        <button type="button" class="qa-subtab active" data-qa-view="scenarios" id="qaSubtabScenarios">1. Chargement des scénarios</button>
+                        <button type="button" class="qa-subtab" data-qa-view="assessment" id="qaSubtabAssessment">2. Cotation</button>
+                        <button type="button" class="qa-subtab" data-qa-view="overview" id="qaSubtabOverview">3. Vue consolidée</button>
+                    </div>
+
+                    <section class="qa-panel active" id="qa-scenarios-panel">
+                        <label class="form-label" id="qaScenariosLabel" for="qaScenariosInput">Collez vos scénarios (1 ligne = 1 scénario, max. 500 caractères)</label>
+                        <textarea id="qaScenariosInput" class="form-textarea qa-scenarios-input" rows="6" placeholder="Paiement indu via intermédiaire"></textarea>
+                        <div class="qa-scenarios-actions">
+                            <button type="button" class="btn btn-primary" id="qaLoadScenariosBtn">Charger les scénarios</button>
+                            <span class="form-helper" id="qaScenariosHelper">Les scénarios remplacent la liste actuelle.</span>
+                        </div>
+                        <div id="qaScenarioList" class="qa-scenario-list"></div>
+                    </section>
+
+                    <section class="qa-panel" id="qa-assessment-panel">
+                        <div class="qa-assessment-grid">
+                            <div class="qa-column">
+                                <div class="qa-selected-caption" id="qaSelectedCaption">Scénario sélectionné</div>
+                                <div class="qa-current-scenario" id="qaCurrentScenario">Aucun scénario sélectionné</div>
+                                <div class="qa-actions-row">
+                                    <button class="btn btn-secondary" type="button" id="qaDuplicateBtn">Dupliquer ce scénario</button>
+                                    <button class="btn btn-danger" type="button" id="qaDeleteBtn">🗑️ Supprimer ce scénario</button>
+                                </div>
+                                <div class="qa-progress"><div id="qaAssessmentProgressFill"></div></div>
+                            </div>
+
+                            <div class="qa-column">
+                                <h4 id="qaRawRiskTitle">Risque brut (inhérent)</h4>
+                                <div class="qa-matrix-wrapper">
+                                    <div id="qaMatrix" class="qa-matrix"></div>
+                                </div>
+                                <div class="qa-legend" id="qaRawLegend">P1 × I1 = 1 (Faible)</div>
+                            </div>
+
+                            <div class="qa-column">
+                                <h4 id="qaAggravatingTitle">Facteurs aggravants</h4>
+                                <div id="qaAggravatingFactors" class="qa-aggravating-list"></div>
+                                <label class="form-label" id="qaEffectivenessLabel" for="qaEffectiveness">Efficacité des mesures de maîtrise</label>
+                                <input type="range" id="qaEffectiveness" min="0" max="75" step="25">
+                                <div class="form-helper" id="qaEffectivenessLegend">0% - Inefficace</div>
+                                <label class="form-label" id="qaCommentLabel" for="qaComment">Commentaires</label>
+                                <textarea id="qaComment" class="form-textarea" rows="4" placeholder="Ajoutez vos observations..."></textarea>
+                                <div class="qa-nav-actions">
+                                    <button class="btn btn-secondary" type="button" id="qaPrevBtn">← Scénario précédent</button>
+                                    <button class="btn btn-secondary" type="button" id="qaNextBtn">Scénario suivant →</button>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="qa-panel" id="qa-overview-panel">
+                        <div class="qa-overview-grid">
+                            <div>
+                                <h4 id="qaOverviewSortedTitle">Risques bruts triés (P × I décroissant)</h4>
+                                <div id="qaOverviewRiskList" class="qa-overview-list"></div>
+                            </div>
+                            <div>
+                                <h4 id="qaOverviewMatrixTitle">Matrice des risques bruts</h4>
+                                <div id="qaOverviewMatrix" class="qa-overview-matrix"></div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -745,7 +828,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.49</span>
+            <span class="app-version">Version 2.14.50</span>
         </footer>
     </div>
 
@@ -1406,6 +1489,7 @@
     <script defer src="assets/js/rms.data.records.js"></script>
     <script defer src="assets/js/rms.matrix.js"></script>
     <script defer src="assets/js/rms.ui.js"></script>
+    <script defer src="assets/js/rms.quick-assessment.js"></script>
     <script defer src="assets/js/rms.core.js"></script>
     <script defer src="assets/js/rms.integrations.js"></script>
     <script defer src="assets/js/feedback.js"></script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5822,3 +5822,183 @@ tbody tr:hover {
         width: auto;
     }
 }
+
+/* Quick assessment */
+.quick-assessment-content {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.qa-subtabs {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.qa-subtab {
+    border: 1px solid var(--border-color);
+    background: white;
+    color: var(--text-secondary);
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.qa-subtab.active {
+    background: var(--primary-color);
+    color: white;
+    border-color: var(--primary-color);
+}
+
+.qa-panel { display: none; }
+.qa-panel.active { display: block; }
+
+.qa-scenarios-input {
+    width: 100%;
+    margin-top: 8px;
+}
+
+.qa-scenarios-actions {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.qa-scenario-list {
+    margin-top: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 280px;
+    overflow: auto;
+}
+
+.qa-scenario-row { display: flex; gap: 8px; }
+.qa-scenario-item {
+    flex: 1;
+    text-align: left;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 8px 10px;
+    background: #fff;
+    cursor: pointer;
+}
+.qa-scenario-item.active {
+    border-color: var(--primary-color);
+    background: rgba(52, 152, 219, 0.09);
+}
+
+.qa-scenario-delete {
+    border: 1px solid var(--danger-color);
+    color: var(--danger-color);
+    border-radius: 8px;
+    background: #fff;
+    padding: 6px 10px;
+    cursor: pointer;
+}
+
+.qa-assessment-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+}
+
+.qa-column {
+    background: #fff;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 12px;
+}
+
+.qa-selected-caption { color: var(--text-secondary); font-size: 12px; }
+.qa-current-scenario { font-weight: 700; margin: 6px 0 10px; }
+.qa-actions-row, .qa-nav-actions { display: flex; gap: 8px; margin-top: 10px; }
+.qa-progress { margin-top: 10px; height: 6px; background: #e9ecef; border-radius: 99px; overflow: hidden; }
+#qaAssessmentProgressFill { height: 100%; width: 0; background: var(--primary-color); }
+
+.qa-matrix-wrapper {
+    width: 100%;
+    max-width: 320px;
+    aspect-ratio: 1;
+}
+
+.qa-matrix,
+.qa-overview-matrix {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+}
+
+.qa-cell {
+    min-height: 56px;
+    border: 1px solid rgba(0,0,0,0.08);
+    border-radius: 8px;
+    position: relative;
+}
+
+.qa-cell.active-cell {
+    outline: 3px solid #2c3e50;
+    outline-offset: -3px;
+}
+
+.qa-legend { margin-top: 10px; font-weight: 600; }
+.qa-aggravating-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+.qa-aggravating-item { display: flex; gap: 8px; align-items: flex-start; font-size: 14px; }
+
+.qa-overview-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+.qa-overview-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 360px;
+    overflow: auto;
+}
+
+.qa-overview-item {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: #fff;
+    text-align: left;
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.qa-overview-item.active {
+    border-color: var(--primary-color);
+    background: rgba(52, 152, 219, 0.09);
+}
+
+.qa-overview-bullet {
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+    background: #fff;
+    margin: 4px;
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.qa-overview-bullet.active {
+    background: var(--primary-color);
+    color: #fff;
+}
+
+@media (max-width: 1200px) {
+    .qa-assessment-grid,
+    .qa-overview-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -1,0 +1,484 @@
+(function () {
+    const STORAGE_KEY = 'rmsQuickAssessmentData';
+    const MAX_SCENARIO_LENGTH = 500;
+    const DEFAULT_AGGRAVATING_FACTORS = [
+        'Pays à risque de corruption élevé (CPI < 40)',
+        'Pays à risque de corruption modéré (40 ≤ CPI < 60)',
+        'Intermédiaires difficiles à contrôler',
+        'Zones géographiques instables',
+        'Secteurs d’activité exposés (BTP, énergie, défense)',
+        'Culture tolérante aux cadeaux',
+        'Turn-over élevé'
+    ];
+    const EFFECTIVENESS_LEVELS = [
+        { value: 0, label: 'Inefficace' },
+        { value: 25, label: 'Insuffisant' },
+        { value: 50, label: 'Améliorable' },
+        { value: 75, label: 'Efficace' }
+    ];
+
+    const state = {
+        view: 'scenarios',
+        data: {
+            version: '2.14.50',
+            scenarios: [],
+            selectedId: null
+        }
+    };
+
+    const dom = {};
+
+    function uid() {
+        return `qa_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    }
+
+    function clampMatrixValue(value) {
+        const num = Number(value);
+        if (!Number.isFinite(num)) return 1;
+        return Math.min(4, Math.max(1, Math.round(num)));
+    }
+
+    function normalizeScenarioText(value) {
+        return String(value || '').trim().slice(0, MAX_SCENARIO_LENGTH);
+    }
+
+    function nearestEffectivenessLevel(value) {
+        const numeric = Math.min(75, Math.max(0, Number(value) || 0));
+        return EFFECTIVENESS_LEVELS.reduce((closest, level) => (
+            Math.abs(level.value - numeric) < Math.abs(closest.value - numeric) ? level : closest
+        ), EFFECTIVENESS_LEVELS[0]).value;
+    }
+
+    function save() {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(state.data));
+    }
+
+    function load() {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        try {
+            const parsed = JSON.parse(raw);
+            if (!parsed || !Array.isArray(parsed.scenarios)) return;
+            state.data = {
+                ...state.data,
+                ...parsed,
+                scenarios: parsed.scenarios
+                    .map((s) => ({
+                        id: s.id || uid(),
+                        text: normalizeScenarioText(s.text),
+                        raw: {
+                            prob: clampMatrixValue(s.raw?.prob),
+                            impact: clampMatrixValue(s.raw?.impact)
+                        },
+                        aggravatingFactors: Array.isArray(s.aggravatingFactors) ? s.aggravatingFactors : [],
+                        effectiveness: nearestEffectivenessLevel(s.effectiveness),
+                        comment: String(s.comment || '')
+                    }))
+                    .filter((s) => s.text)
+            };
+            ensureSelection();
+        } catch (_error) {
+            localStorage.removeItem(STORAGE_KEY);
+        }
+    }
+
+    function ensureSelection() {
+        if (!state.data.scenarios.length) {
+            state.data.selectedId = null;
+            return;
+        }
+        if (!state.data.scenarios.some((scenario) => scenario.id === state.data.selectedId)) {
+            state.data.selectedId = state.data.scenarios[0].id;
+        }
+    }
+
+    function getCurrentScenario() {
+        return state.data.scenarios.find((scenario) => scenario.id === state.data.selectedId) || null;
+    }
+
+    function scoreToLevel(score) {
+        if (score >= 13) return 4;
+        if (score >= 9) return 3;
+        if (score >= 5) return 2;
+        return 1;
+    }
+
+    function scoreLabel(score) {
+        if (score >= 12) return 'Élevé';
+        if (score >= 6) return 'Modéré';
+        return 'Faible';
+    }
+
+    function replaceScenariosFromText(inputText) {
+        const lines = String(inputText || '')
+            .split(/\r?\n/)
+            .map((line) => normalizeScenarioText(line))
+            .filter(Boolean);
+
+        state.data.scenarios = lines.map((text) => ({
+            id: uid(),
+            text,
+            raw: { prob: 1, impact: 1 },
+            aggravatingFactors: [],
+            effectiveness: 0,
+            comment: ''
+        }));
+        state.data.selectedId = state.data.scenarios[0]?.id || null;
+        render();
+        save();
+    }
+
+    function updateCurrentScenario(patch) {
+        const scenario = getCurrentScenario();
+        if (!scenario) return;
+        Object.assign(scenario, patch);
+        save();
+        renderAssessment();
+        renderOverview();
+        renderScenarioList();
+    }
+
+    function deleteScenario(id) {
+        const index = state.data.scenarios.findIndex((scenario) => scenario.id === id);
+        if (index < 0) return;
+        state.data.scenarios.splice(index, 1);
+        const fallback = state.data.scenarios[index] || state.data.scenarios[index - 1] || null;
+        state.data.selectedId = fallback?.id || null;
+        render();
+        save();
+    }
+
+    function renderScenarioList() {
+        dom.scenarioList.innerHTML = '';
+        if (!state.data.scenarios.length) {
+            dom.scenarioList.innerHTML = '<div class="interview-empty">Aucun scénario chargé pour le moment.</div>';
+            return;
+        }
+
+        state.data.scenarios.forEach((scenario, index) => {
+            const row = document.createElement('div');
+            row.className = 'qa-scenario-row';
+
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = `qa-scenario-item ${scenario.id === state.data.selectedId ? 'active' : ''}`;
+            button.textContent = `${index + 1}. ${scenario.text}`;
+            button.addEventListener('click', () => {
+                state.data.selectedId = scenario.id;
+                render();
+                save();
+            });
+
+            const del = document.createElement('button');
+            del.type = 'button';
+            del.className = 'qa-scenario-delete';
+            del.textContent = '🗑️';
+            del.addEventListener('click', () => deleteScenario(scenario.id));
+
+            row.appendChild(button);
+            row.appendChild(del);
+            dom.scenarioList.appendChild(row);
+        });
+    }
+
+    function renderMatrix() {
+        dom.matrix.innerHTML = '';
+        for (let impact = 4; impact >= 1; impact -= 1) {
+            for (let prob = 1; prob <= 4; prob += 1) {
+                const score = prob * impact;
+                const cell = document.createElement('button');
+                cell.type = 'button';
+                cell.className = `matrix-cell qa-cell level-${scoreToLevel(score)}`;
+                cell.dataset.prob = String(prob);
+                cell.dataset.impact = String(impact);
+                cell.addEventListener('click', () => updateCurrentScenario({ raw: { prob, impact } }));
+                dom.matrix.appendChild(cell);
+            }
+        }
+    }
+
+    function renderAggravatingFactors(scenario) {
+        dom.aggravatingFactors.innerHTML = '';
+        DEFAULT_AGGRAVATING_FACTORS.forEach((factor) => {
+            const label = document.createElement('label');
+            label.className = 'qa-aggravating-item';
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = Boolean(scenario?.aggravatingFactors?.includes(factor));
+            input.disabled = !scenario;
+            input.addEventListener('change', () => {
+                if (!scenario) return;
+                const factorSet = new Set(scenario.aggravatingFactors || []);
+                if (input.checked) factorSet.add(factor);
+                else factorSet.delete(factor);
+                updateCurrentScenario({ aggravatingFactors: [...factorSet] });
+            });
+            const text = document.createElement('span');
+            text.textContent = factor;
+            label.append(input, text);
+            dom.aggravatingFactors.appendChild(label);
+        });
+    }
+
+    function renderAssessment() {
+        const scenario = getCurrentScenario();
+        const disabled = !scenario;
+        dom.currentScenario.textContent = scenario?.text || 'Aucun scénario sélectionné';
+        dom.duplicateBtn.disabled = disabled;
+        dom.deleteBtn.disabled = disabled;
+        dom.prevBtn.disabled = disabled;
+        dom.nextBtn.disabled = disabled;
+        dom.effectiveness.disabled = disabled;
+        dom.comment.disabled = disabled;
+
+        renderAggravatingFactors(scenario);
+
+        if (!scenario) {
+            dom.rawLegend.textContent = 'P1 × I1 = 1 (Faible)';
+            dom.effectiveness.value = 0;
+            dom.effectivenessLegend.textContent = '0% - Inefficace';
+            dom.comment.value = '';
+            dom.matrix.querySelectorAll('.qa-cell').forEach((cell) => cell.classList.remove('active-cell'));
+            return;
+        }
+
+        const prob = clampMatrixValue(scenario.raw?.prob);
+        const impact = clampMatrixValue(scenario.raw?.impact);
+        const score = prob * impact;
+        dom.rawLegend.textContent = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
+
+        dom.matrix.querySelectorAll('.qa-cell').forEach((cell) => {
+            const active = Number(cell.dataset.prob) === prob && Number(cell.dataset.impact) === impact;
+            cell.classList.toggle('active-cell', active);
+        });
+
+        const snapped = nearestEffectivenessLevel(scenario.effectiveness);
+        dom.effectiveness.value = snapped;
+        dom.effectivenessLegend.textContent = `${snapped}% - ${EFFECTIVENESS_LEVELS.find((l) => l.value === snapped)?.label || 'Inefficace'}`;
+        dom.comment.value = scenario.comment || '';
+
+        const idx = state.data.scenarios.findIndex((s) => s.id === scenario.id);
+        dom.prevBtn.disabled = idx <= 0;
+        dom.nextBtn.disabled = idx >= state.data.scenarios.length - 1;
+        dom.assessmentProgressFill.style.width = `${((idx + 1) / state.data.scenarios.length) * 100}%`;
+    }
+
+    function getSortedScenarios() {
+        return [...state.data.scenarios].sort((a, b) => (b.raw.prob * b.raw.impact) - (a.raw.prob * a.raw.impact));
+    }
+
+    function renderOverview() {
+        dom.overviewList.innerHTML = '';
+        dom.overviewMatrix.innerHTML = '';
+        const sorted = getSortedScenarios();
+
+        if (!sorted.length) {
+            dom.overviewList.innerHTML = '<div class="interview-empty">Aucun risque coté pour le moment.</div>';
+            dom.overviewMatrix.innerHTML = '<div class="interview-empty">Chargez des scénarios pour afficher la matrice consolidée.</div>';
+            return;
+        }
+
+        sorted.forEach((scenario, index) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = `qa-overview-item ${scenario.id === state.data.selectedId ? 'active' : ''}`;
+            btn.innerHTML = `<strong>${index + 1}. ${scenario.text}</strong><span>Score ${scenario.raw.prob * scenario.raw.impact} • P${scenario.raw.prob} × I${scenario.raw.impact}</span>`;
+            btn.addEventListener('click', () => {
+                state.data.selectedId = scenario.id;
+                save();
+                render();
+            });
+            dom.overviewList.appendChild(btn);
+        });
+
+        for (let impact = 4; impact >= 1; impact -= 1) {
+            for (let prob = 1; prob <= 4; prob += 1) {
+                const cell = document.createElement('div');
+                cell.className = `matrix-cell qa-cell qa-overview-cell level-${scoreToLevel(prob * impact)}`;
+                const risks = sorted.filter((s) => s.raw.prob === prob && s.raw.impact === impact);
+                risks.slice(0, 9).forEach((scenario, idx) => {
+                    const bullet = document.createElement('button');
+                    bullet.type = 'button';
+                    bullet.className = `qa-overview-bullet ${scenario.id === state.data.selectedId ? 'active' : ''}`;
+                    bullet.textContent = String(idx + 1);
+                    bullet.title = scenario.text;
+                    bullet.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        state.data.selectedId = scenario.id;
+                        save();
+                        render();
+                    });
+                    cell.appendChild(bullet);
+                });
+                dom.overviewMatrix.appendChild(cell);
+            }
+        }
+    }
+
+    function setView(view) {
+        state.view = view;
+        document.querySelectorAll('.qa-subtab').forEach((btn) => btn.classList.toggle('active', btn.dataset.qaView === view));
+        dom.scenariosPanel.classList.toggle('active', view === 'scenarios');
+        dom.assessmentPanel.classList.toggle('active', view === 'assessment');
+        dom.overviewPanel.classList.toggle('active', view === 'overview');
+    }
+
+    function exportJson() {
+        const payload = JSON.stringify(state.data, null, 2);
+        const blob = new Blob([payload], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `quick-assessment-${new Date().toISOString().slice(0, 10)}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function csvEscape(value) {
+        const v = String(value ?? '');
+        const e = v.replace(/"/g, '""');
+        return /[";\n]/.test(e) ? `"${e}"` : e;
+    }
+
+    function exportCsv() {
+        const rows = [
+            ['Scénario', 'Probabilité', 'Impact', 'Score', 'Facteurs aggravants', 'Efficacité', 'Commentaire'],
+            ...state.data.scenarios.map((scenario) => [
+                scenario.text,
+                scenario.raw.prob,
+                scenario.raw.impact,
+                scenario.raw.prob * scenario.raw.impact,
+                (scenario.aggravatingFactors || []).join(' | '),
+                `${nearestEffectivenessLevel(scenario.effectiveness)}%`,
+                scenario.comment || ''
+            ])
+        ];
+        const csv = rows.map((row) => row.map(csvEscape).join(';')).join('\n');
+        const blob = new Blob([`\uFEFF${csv}`], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `quick-assessment-${new Date().toISOString().slice(0, 10)}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    function importJson(file) {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+            try {
+                const parsed = JSON.parse(String(reader.result || '{}'));
+                if (!parsed || !Array.isArray(parsed.scenarios)) throw new Error('Format invalide');
+                state.data.scenarios = parsed.scenarios
+                    .map((s) => ({
+                        id: s.id || uid(),
+                        text: normalizeScenarioText(s.text),
+                        raw: { prob: clampMatrixValue(s.raw?.prob), impact: clampMatrixValue(s.raw?.impact) },
+                        aggravatingFactors: Array.isArray(s.aggravatingFactors) ? s.aggravatingFactors : [],
+                        effectiveness: nearestEffectivenessLevel(s.effectiveness),
+                        comment: String(s.comment || '')
+                    }))
+                    .filter((s) => s.text);
+                state.data.selectedId = state.data.scenarios[0]?.id || null;
+                save();
+                render();
+            } catch (error) {
+                alert(`Import impossible : ${error.message}`);
+            }
+        };
+        reader.readAsText(file);
+    }
+
+    function bindEvents() {
+        document.querySelectorAll('.qa-subtab').forEach((btn) => {
+            btn.addEventListener('click', () => setView(btn.dataset.qaView));
+        });
+
+        dom.loadScenariosBtn.addEventListener('click', () => replaceScenariosFromText(dom.scenariosInput.value));
+
+        dom.duplicateBtn.addEventListener('click', () => {
+            const current = getCurrentScenario();
+            if (!current) return;
+            const copy = { ...current, id: uid(), text: `${current.text} (copie)`, raw: { ...current.raw }, aggravatingFactors: [...(current.aggravatingFactors || [])] };
+            const index = state.data.scenarios.findIndex((s) => s.id === current.id);
+            state.data.scenarios.splice(index + 1, 0, copy);
+            state.data.selectedId = copy.id;
+            save();
+            render();
+        });
+
+        dom.deleteBtn.addEventListener('click', () => deleteScenario(state.data.selectedId));
+        dom.prevBtn.addEventListener('click', () => {
+            const idx = state.data.scenarios.findIndex((s) => s.id === state.data.selectedId);
+            if (idx > 0) state.data.selectedId = state.data.scenarios[idx - 1].id;
+            save();
+            render();
+        });
+        dom.nextBtn.addEventListener('click', () => {
+            const idx = state.data.scenarios.findIndex((s) => s.id === state.data.selectedId);
+            if (idx < state.data.scenarios.length - 1) state.data.selectedId = state.data.scenarios[idx + 1].id;
+            save();
+            render();
+        });
+
+        dom.effectiveness.addEventListener('input', (evt) => {
+            const value = nearestEffectivenessLevel(evt.target.value);
+            evt.target.value = value;
+            updateCurrentScenario({ effectiveness: value });
+        });
+
+        dom.comment.addEventListener('input', (evt) => updateCurrentScenario({ comment: evt.target.value }));
+
+        dom.exportJsonBtn.addEventListener('click', exportJson);
+        dom.exportCsvBtn.addEventListener('click', exportCsv);
+        dom.importBtn.addEventListener('click', () => dom.importFile.click());
+        dom.importFile.addEventListener('change', (evt) => {
+            importJson(evt.target.files[0]);
+            evt.target.value = '';
+        });
+    }
+
+    function render() {
+        ensureSelection();
+        renderScenarioList();
+        renderAssessment();
+        renderOverview();
+    }
+
+    function init() {
+        dom.scenariosInput = document.getElementById('qaScenariosInput');
+        if (!dom.scenariosInput) return;
+        dom.loadScenariosBtn = document.getElementById('qaLoadScenariosBtn');
+        dom.scenarioList = document.getElementById('qaScenarioList');
+        dom.scenariosPanel = document.getElementById('qa-scenarios-panel');
+        dom.assessmentPanel = document.getElementById('qa-assessment-panel');
+        dom.overviewPanel = document.getElementById('qa-overview-panel');
+        dom.matrix = document.getElementById('qaMatrix');
+        dom.currentScenario = document.getElementById('qaCurrentScenario');
+        dom.duplicateBtn = document.getElementById('qaDuplicateBtn');
+        dom.deleteBtn = document.getElementById('qaDeleteBtn');
+        dom.rawLegend = document.getElementById('qaRawLegend');
+        dom.aggravatingFactors = document.getElementById('qaAggravatingFactors');
+        dom.effectiveness = document.getElementById('qaEffectiveness');
+        dom.effectivenessLegend = document.getElementById('qaEffectivenessLegend');
+        dom.comment = document.getElementById('qaComment');
+        dom.prevBtn = document.getElementById('qaPrevBtn');
+        dom.nextBtn = document.getElementById('qaNextBtn');
+        dom.assessmentProgressFill = document.getElementById('qaAssessmentProgressFill');
+        dom.overviewList = document.getElementById('qaOverviewRiskList');
+        dom.overviewMatrix = document.getElementById('qaOverviewMatrix');
+        dom.exportJsonBtn = document.getElementById('qaExportJsonBtn');
+        dom.exportCsvBtn = document.getElementById('qaExportCsvBtn');
+        dom.importBtn = document.getElementById('qaImportBtn');
+        dom.importFile = document.getElementById('qaImportFile');
+
+        load();
+        renderMatrix();
+        bindEvents();
+        setView('scenarios');
+        render();
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
### Motivation
- Provide a lightweight workflow to quickly load, score and review risk scenarios directly in the app, using the same design language and scoring scales as existing matrices. 
- Allow rapid import/export and local persistence for quick assessments to speed analyst workflows. 
- Keep the feature isolated from existing RMS code by namespacing UI and logic to avoid collisions. 
- Update the application footer version as required (new version: `2.14.50`).

### Description
- Adds a new top-level tab `⚡ Quick assessment` positioned after `Interviews` in `CartoModel.html` and wires it into the existing `switchTab()` flow. 
- Implements the quick assessment module in `assets/js/rms.quick-assessment.js` with localStorage persistence, scenario parsing/normalization, P×I scoring, aggravating factors, effectiveness snapping, per-scenario navigation, and JSON/CSV export + JSON import. 
- Adds scoped UI and styles in `assets/css/main.css` (classes/IDs prefixed with `qa-`) to match the app look-and-feel and remain isolated from other components. 
- Updates `CartoModel.html` to include the tab markup, sub-tabs (scenarios / assessment / overview), to load the new script, and bumps the footer `Version` to `2.14.50`.

### Testing
- Ran a JavaScript syntax check with `node --check assets/js/rms.quick-assessment.js`, which succeeded. 
- Verified files staged and committed (`git status` / commit performed) after changes were applied. 
- No automated UI/browser tests were executed in this environment; visual verification should be performed in-browser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6144c6d24832e889a493ba14a64d5)