### PR TITLE
Corrige l'indentation des puces en mode view et incrémente la version à 2.14.53

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.52</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.53</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -840,7 +840,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.52</span>
+            <span class="app-version">Version 2.14.53</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3679,6 +3679,16 @@ tbody tr:hover {
     overflow-y: auto;
 }
 
+.interview-view-notes ul,
+.interview-view-notes ol {
+    margin: 0 0 0.8rem;
+    padding-left: 1.4rem;
+}
+
+.interview-view-notes li {
+    margin-bottom: 0.3rem;
+}
+
 .interview-view-notes p:last-child,
 .interview-view-notes ul:last-child,
 .interview-view-notes ol:last-child {

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -20,7 +20,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.52',
+            version: '2.14.53',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- Les listes insérées dans les notes d'entretien perdaient leur indentation en mode “view”, rendant la lecture difficile.
- La version affichée dans le footer devait être incrémentée conformément à la règle de versioning (footer mis à jour vers `2.14.53`).

### Description
- Ajout de règles CSS pour `.interview-view-notes ul`, `.interview-view-notes ol` et `.interview-view-notes li` pour rétablir le padding et l'espacement des puces (fichier `assets/css/main.css`).
- Mise à jour de la version affichée dans le document et le footer vers `2.14.53` (fichier `CartoModel.html`).
- Harmonisation de la version interne du module quick assessment à `2.14.53` (fichier `assets/js/rms.quick-assessment.js`).

### Testing
- Exécution de `node --check assets/js/rms.quick-assessment.js`, qui a réussi.
- Vérification du diff des fichiers modifiés pour confirmer l'ajout des règles CSS et la mise à jour des numéros de version, sans erreurs de syntaxe détectées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61bdb174c832ea58cc1c328f41dda)