### PR TITLE
Améliore l’UX du quick-assessment : boutons icônes, matrice draggable, commentaire ; version 2.14.55

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.53</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.55</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -394,8 +394,8 @@
                                 <div class="qa-selected-caption" id="qaSelectedCaption">Selected scenario</div>
                                 <div class="qa-current-scenario" id="qaCurrentScenario">No scenario selected</div>
                                 <div class="qa-actions-row">
-                                    <button class="btn btn-secondary" type="button" id="qaDuplicateBtn">Duplicate this scenario</button>
-                                    <button class="btn btn-danger" type="button" id="qaDeleteBtn">🗑️ Delete this scenario</button>
+                                    <button class="btn btn-secondary btn-icon" type="button" id="qaDuplicateBtn" title="Duplicate this scenario" aria-label="Duplicate this scenario">⧉</button>
+                                    <button class="btn btn-danger btn-icon" type="button" id="qaDeleteBtn" title="Delete this scenario" aria-label="Delete this scenario">🗑️</button>
                                 </div>
                                 <div class="qa-progress"><div id="qaAssessmentProgressFill"></div></div>
                             </div>
@@ -430,7 +430,7 @@
                             </div>
 
                             <div class="qa-card qa-card-comment">
-                                <label class="form-label" id="qaCommentLabel" for="qaComment">Commentaires</label>
+                                <label class="form-label" id="qaCommentLabel" for="qaComment">Commentaire</label>
                                 <textarea id="qaComment" class="form-textarea" rows="4" placeholder="Ajoutez vos observations..."></textarea>
                                 <div class="qa-nav-actions">
                                     <button class="btn btn-secondary" type="button" id="qaPrevBtn">← Previous scenario</button>
@@ -856,7 +856,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.54</span>
+            <span class="app-version">Version 2.14.55</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5937,6 +5937,17 @@ tbody tr:hover {
 .qa-selected-caption { color: var(--text-secondary); font-size: 12px; }
 .qa-current-scenario { font-weight: 700; margin: 6px 0 10px; }
 .qa-actions-row, .qa-nav-actions { display: flex; gap: 8px; margin-top: 10px; }
+.qa-actions-row { justify-content: flex-end; }
+.btn.btn-icon {
+    width: 44px;
+    min-width: 44px;
+    height: 40px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+}
 .qa-progress { margin-top: 10px; height: 6px; background: #e9ecef; border-radius: 99px; overflow: hidden; }
 #qaAssessmentProgressFill { height: 100%; width: 0; background: var(--primary-color); }
 
@@ -5952,6 +5963,11 @@ tbody tr:hover {
     grid-template-columns: repeat(4, 1fr);
     gap: 6px;
 }
+.qa-matrix {
+    position: relative;
+    touch-action: none;
+    user-select: none;
+}
 
 .qa-cell {
     min-height: 56px;
@@ -5963,6 +5979,21 @@ tbody tr:hover {
 .qa-cell.active-cell {
     outline: 3px solid #2c3e50;
     outline-offset: -3px;
+}
+.qa-matrix-dot {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    border-radius: 999px;
+    border: 3px solid #fff;
+    background: linear-gradient(135deg, #4b91c5, #0061af);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 3;
+    transform: translate(-50%, -50%);
+    cursor: grab;
+}
+.qa-matrix-dot.dragging {
+    cursor: grabbing;
 }
 
 .qa-legend { margin-top: 10px; font-weight: 600; }
@@ -5988,6 +6019,14 @@ tbody tr:hover {
 }
 .qa-aggravating-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
 .qa-aggravating-item { display: flex; gap: 8px; align-items: flex-start; font-size: 14px; }
+.qa-card-comment .form-label {
+    display: block;
+    margin-bottom: 8px;
+}
+.qa-card-comment .form-textarea {
+    width: 100%;
+    min-height: 120px;
+}
 
 .qa-overview-grid {
     display: grid;

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,13 +76,15 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.54',
+            version: '2.14.55',
             scenarios: [],
             selectedId: null
         }
     };
 
     const dom = {};
+    let qaMatrixDragPointerId = null;
+    let qaMatrixLastCell = null;
 
     function uid() {
         return `qa_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -242,15 +244,87 @@
         for (let impact = 4; impact >= 1; impact -= 1) {
             for (let prob = 1; prob <= 4; prob += 1) {
                 const score = prob * impact;
-                const cell = document.createElement('button');
-                cell.type = 'button';
+                const cell = document.createElement('div');
                 cell.className = `matrix-cell qa-cell level-${scoreToLevel(score)}`;
                 cell.dataset.prob = String(prob);
                 cell.dataset.impact = String(impact);
-                cell.addEventListener('click', () => updateCurrentScenario({ raw: { prob, impact } }));
                 dom.matrix.appendChild(cell);
             }
         }
+
+        const dot = document.createElement('div');
+        dot.className = 'qa-matrix-dot';
+        dot.id = 'qaMatrixDot';
+        dot.setAttribute('role', 'button');
+        dot.setAttribute('aria-label', 'Move risk point');
+        dot.addEventListener('pointerdown', startQaMatrixDrag);
+        dot.addEventListener('pointermove', moveQaMatrixDrag);
+        dot.addEventListener('pointerup', endQaMatrixDrag);
+        dot.addEventListener('pointercancel', endQaMatrixDrag);
+        dom.matrix.appendChild(dot);
+        dom.matrixDot = dot;
+
+        if (!dom.matrix.dataset.pointerListener) {
+            dom.matrix.addEventListener('pointerdown', handleQaMatrixPointerDown);
+            dom.matrix.dataset.pointerListener = 'true';
+        }
+    }
+
+    function getQaMatrixCellFromEvent(event) {
+        if (!dom.matrix) return null;
+        const rect = dom.matrix.getBoundingClientRect();
+        if (!rect.width || !rect.height) return null;
+        const x = event.clientX - rect.left;
+        const y = event.clientY - rect.top;
+        if (x < 0 || y < 0 || x > rect.width || y > rect.height) return null;
+        const prob = Math.min(4, Math.max(1, Math.ceil(x / (rect.width / 4))));
+        const rowIndex = Math.min(3, Math.max(0, Math.floor(y / (rect.height / 4))));
+        const impact = 4 - rowIndex;
+        return { prob, impact };
+    }
+
+    function setQaMatrixValue(prob, impact) {
+        updateCurrentScenario({ raw: { prob, impact } });
+    }
+
+    function startQaMatrixDrag(event) {
+        const scenario = getCurrentScenario();
+        if (!scenario) return;
+        qaMatrixDragPointerId = event.pointerId;
+        qaMatrixLastCell = null;
+        dom.matrixDot.classList.add('dragging');
+        dom.matrixDot.setPointerCapture(event.pointerId);
+        event.preventDefault();
+    }
+
+    function moveQaMatrixDrag(event) {
+        if (qaMatrixDragPointerId !== event.pointerId) return;
+        const cell = getQaMatrixCellFromEvent(event);
+        if (!cell) return;
+        if (!qaMatrixLastCell || qaMatrixLastCell.prob !== cell.prob || qaMatrixLastCell.impact !== cell.impact) {
+            qaMatrixLastCell = cell;
+            setQaMatrixValue(cell.prob, cell.impact);
+        }
+    }
+
+    function endQaMatrixDrag(event) {
+        if (qaMatrixDragPointerId !== event.pointerId) return;
+        if (dom.matrixDot?.hasPointerCapture(event.pointerId)) {
+            dom.matrixDot.releasePointerCapture(event.pointerId);
+        }
+        dom.matrixDot.classList.remove('dragging');
+        const fallback = getCurrentScenario()?.raw || { prob: 1, impact: 1 };
+        const cell = getQaMatrixCellFromEvent(event) || qaMatrixLastCell || fallback;
+        setQaMatrixValue(cell.prob, cell.impact);
+        qaMatrixDragPointerId = null;
+        qaMatrixLastCell = null;
+    }
+
+    function handleQaMatrixPointerDown(event) {
+        if (!getCurrentScenario()) return;
+        if (event.target === dom.matrixDot) return;
+        const cell = getQaMatrixCellFromEvent(event);
+        if (cell) setQaMatrixValue(cell.prob, cell.impact);
     }
 
     function renderAggravatingFactors(scenario) {
@@ -300,6 +374,9 @@
             dom.effectivenessLegend.textContent = '0% - Ineffective';
             dom.comment.value = '';
             dom.matrix.querySelectorAll('.qa-cell').forEach((cell) => cell.classList.remove('active-cell'));
+            if (dom.matrixDot) {
+                dom.matrixDot.style.display = 'none';
+            }
             return;
         }
 
@@ -318,6 +395,13 @@
             const active = Number(cell.dataset.prob) === prob && Number(cell.dataset.impact) === impact;
             cell.classList.toggle('active-cell', active);
         });
+        if (dom.matrixDot) {
+            const left = ((prob - 0.5) / 4) * 100;
+            const top = ((4 - impact + 0.5) / 4) * 100;
+            dom.matrixDot.style.left = `${left}%`;
+            dom.matrixDot.style.top = `${top}%`;
+            dom.matrixDot.style.display = 'block';
+        }
 
         const snapped = nearestEffectivenessLevel(scenario.effectiveness);
         dom.effectiveness.value = snapped;


### PR DESCRIPTION
### Motivation
- Aligner et compacter les actions scénario en utilisant uniquement des icônes pour gagner de la place et améliorer l’accessibilité. 
- Harmoniser la matrice de la cotation rapide avec l’onglet “Risk Matrix” en ajoutant une puce déplaçable (drag & drop) pour positionner P/I intuitivement. 
- Clarifier le bloc « Commentaire » en plaçant le label au-dessus et en étendant le textarea pour faciliter la saisie, et mettre à jour la version d’interface (voir ci‑dessous). 
- Version mise à jour pour cette tâche : `2.14.55`.

### Description
- Remplacement des boutons textuels dans la carte scénario par des boutons icônes et alignement à droite en modifiant `CartoModel.html` (ajout d’attributs `title` et `aria-label`).
- Ajout de la puce draggable et gestion des interactions pointer dans `assets/js/rms.quick-assessment.js` (création de la puce `qa-matrix-dot`, mapping pointeur → cellule, events `pointerdown/move/up/cancel`, synchronisation visuelle avec cellules actives) et remplacement des cellules cliquables par des `div` pour faciliter le drag.
- Ajout des styles nécessaires dans `assets/css/main.css` (`.btn.btn-icon`, alignement `.qa-actions-row`, styles `.qa-matrix-dot`, adaptation `.qa-matrix` et amélioration du layout du bloc commentaire).
- Mise à jour des mentions de version à `2.14.55` dans le `title`, le footer et la donnée `version` du quick assessment (`CartoModel.html` et `assets/js/rms.quick-assessment.js`).

### Testing
- Exécution de la vérification syntaxique JavaScript avec `node --check assets/js/rms.quick-assessment.js` qui a réussi.
- Aucune autre suite de tests automatisés disponible dans l’environnement, pas d’erreur JS détectée lors de la vérification précédente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e620185244832eb831fa27bb17633d)