### PR TITLE
Improve QA matrix UI and bump app version to 2.14.56

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.55</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.56</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -403,7 +403,14 @@
                             <div class="qa-card qa-card-matrix">
                                 <h4 id="qaRawRiskTitle">Gross risk (inherent)</h4>
                                 <div class="qa-matrix-wrapper">
-                                    <div id="qaMatrix" class="qa-matrix"></div>
+                                    <div class="qa-matrix-surface">
+                                        <div id="qaMatrix" class="qa-matrix"></div>
+                                        <div class="axis-label x-axis">Likelihood →</div>
+                                        <div class="axis-label y-axis">
+                                            <span class="axis-text">Impact</span>
+                                            <span class="axis-arrow" aria-hidden="true">↑</span>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
 
@@ -448,7 +455,16 @@
                             </div>
                             <div>
                                 <h4 id="qaOverviewMatrixTitle">Matrice des risques bruts</h4>
-                                <div id="qaOverviewMatrix" class="qa-overview-matrix"></div>
+                                <div class="qa-matrix-wrapper qa-overview-matrix-wrapper">
+                                    <div class="qa-matrix-surface">
+                                        <div id="qaOverviewMatrix" class="qa-overview-matrix"></div>
+                                        <div class="axis-label x-axis">Likelihood →</div>
+                                        <div class="axis-label y-axis">
+                                            <span class="axis-text">Impact</span>
+                                            <span class="axis-arrow" aria-hidden="true">↑</span>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </section>
@@ -856,7 +872,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.55</span>
+            <span class="app-version">Version 2.14.56</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5953,32 +5953,47 @@ tbody tr:hover {
 
 .qa-matrix-wrapper {
     width: 100%;
-    max-width: 320px;
+    max-width: 520px;
     aspect-ratio: 1;
+    margin: 0 auto;
+}
+
+.qa-matrix-surface {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border: 2px solid var(--secondary-color);
+    background: var(--surface-color);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+}
+
+.qa-overview-matrix-wrapper {
+    max-width: 520px;
 }
 
 .qa-matrix,
 .qa-overview-matrix {
+    position: absolute;
+    inset: 0;
     display: grid;
     grid-template-columns: repeat(4, 1fr);
-    gap: 6px;
+    grid-template-rows: repeat(4, 1fr);
+    gap: 0;
 }
 .qa-matrix {
-    position: relative;
     touch-action: none;
     user-select: none;
 }
 
 .qa-cell {
-    min-height: 56px;
-    border: 1px solid rgba(0,0,0,0.08);
-    border-radius: 8px;
+    border: 1px solid var(--border-color);
     position: relative;
+    transition: all 0.3s ease;
 }
 
 .qa-cell.active-cell {
-    outline: 3px solid #2c3e50;
-    outline-offset: -3px;
+    box-shadow: inset 0 0 0 3px #2c3e50;
+    z-index: 1;
 }
 .qa-matrix-dot {
     position: absolute;
@@ -6063,17 +6078,18 @@ tbody tr:hover {
     width: 22px;
     height: 22px;
     border-radius: 999px;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    background: #fff;
+    border: 3px solid #fff;
+    color: #fff;
+    background: linear-gradient(135deg, #4b91c5, #0061af);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     margin: 4px;
     font-size: 11px;
+    font-weight: 700;
     cursor: pointer;
 }
 
 .qa-overview-bullet.active {
-    background: var(--primary-color);
-    color: #fff;
+    box-shadow: 0 0 0 3px rgba(11, 61, 96, 0.25), 0 2px 8px rgba(0, 0, 0, 0.25);
 }
 
 @media (max-width: 1200px) {

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.55',
+            version: '2.14.56',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation

- Improve the quick-assessment risk matrix visual presentation and usability by adding axis labels and a distinct matrix surface container. 
- Update app version metadata to reflect the release bump to `2.14.56`.

### Description

- Added a `.qa-matrix-surface` wrapper around matrix elements and injected axis labels for `Likelihood →` and `Impact ↑` in both the assessment and overview matrices in `CartoModel.html`.
- Restyled the matrix and overview matrix in `assets/css/main.css` by increasing `max-width`, making the matrix a positioned grid with an inset layout, adding a bordered surface, shadows, transitions, and updated cell and bullet visuals. 
- Adjusted overview matrix wrapper class and improved dot/bullet styling for better contrast and emphasis. 
- Bumped the runtime `version` in `assets/js/rms.quick-assessment.js` and the title/footer strings in `CartoModel.html` from `2.14.55` to `2.14.56`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6224b210c832e9362a1454bd3253e)