### PR TITLE
Update consolidated quick assessment matrix labels and ranking

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.56</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.57</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -454,14 +454,25 @@
                                 <div id="qaOverviewRiskList" class="qa-overview-list"></div>
                             </div>
                             <div>
-                                <h4 id="qaOverviewMatrixTitle">Matrice des risques bruts</h4>
-                                <div class="qa-matrix-wrapper qa-overview-matrix-wrapper">
-                                    <div class="qa-matrix-surface">
-                                        <div id="qaOverviewMatrix" class="qa-overview-matrix"></div>
-                                        <div class="axis-label x-axis">Likelihood →</div>
-                                        <div class="axis-label y-axis">
-                                            <span class="axis-text">Impact</span>
-                                            <span class="axis-arrow" aria-hidden="true">↑</span>
+                                <h4 id="qaOverviewMatrixTitle">Gross risk matrix</h4>
+                                <div class="qa-overview-matrix-layout">
+                                    <div class="qa-overview-row-labels" aria-hidden="true">
+                                        <span>Critical impact</span>
+                                        <span>High impact</span>
+                                        <span>Moderate impact</span>
+                                        <span>Low impact</span>
+                                    </div>
+                                    <div class="qa-overview-matrix-stage">
+                                        <div class="qa-matrix-wrapper qa-overview-matrix-wrapper">
+                                            <div class="qa-matrix-surface">
+                                                <div id="qaOverviewMatrix" class="qa-overview-matrix"></div>
+                                            </div>
+                                        </div>
+                                        <div class="qa-overview-col-labels" aria-hidden="true">
+                                            <span>Unlikely</span>
+                                            <span>Moderately likely</span>
+                                            <span>Likely</span>
+                                            <span>Very likely</span>
                                         </div>
                                     </div>
                                 </div>
@@ -872,7 +883,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.56</span>
+            <span class="app-version">Version 2.14.57</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6049,6 +6049,47 @@ tbody tr:hover {
     gap: 12px;
 }
 
+.qa-overview-matrix-layout {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    gap: 12px;
+    align-items: start;
+}
+
+.qa-overview-matrix-stage {
+    width: 100%;
+}
+
+.qa-overview-row-labels,
+.qa-overview-col-labels {
+    color: #0f2544;
+    font-weight: 600;
+}
+
+.qa-overview-row-labels {
+    display: grid;
+    grid-template-rows: repeat(4, minmax(0, 1fr));
+    min-height: 520px;
+}
+
+.qa-overview-row-labels span {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    text-align: right;
+    padding-right: 4px;
+}
+
+.qa-overview-col-labels {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    margin-top: 10px;
+}
+
+.qa-overview-col-labels span {
+    text-align: center;
+}
+
 .qa-overview-list {
     display: flex;
     flex-direction: column;
@@ -6096,6 +6137,20 @@ tbody tr:hover {
     .qa-assessment-grid,
     .qa-overview-grid {
         grid-template-columns: 1fr;
+    }
+    .qa-overview-matrix-layout {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+    .qa-overview-row-labels {
+        min-height: auto;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        grid-template-rows: 1fr;
+    }
+    .qa-overview-row-labels span {
+        justify-content: center;
+        text-align: center;
+        padding-right: 0;
     }
     .qa-assessment-grid {
         grid-template-areas:

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.56',
+            version: '2.14.57',
             scenarios: [],
             selectedId: null
         }
@@ -422,6 +422,7 @@
         dom.overviewList.innerHTML = '';
         dom.overviewMatrix.innerHTML = '';
         const sorted = getSortedScenarios();
+        const rankingByScenarioId = new Map(sorted.map((scenario, index) => [scenario.id, index + 1]));
 
         if (!sorted.length) {
             dom.overviewList.innerHTML = '<div class="interview-empty">No assessed risk yet.</div>';
@@ -447,11 +448,11 @@
                 const cell = document.createElement('div');
                 cell.className = `matrix-cell qa-cell qa-overview-cell level-${scoreToLevel(prob * impact)}`;
                 const risks = sorted.filter((s) => s.raw.prob === prob && s.raw.impact === impact);
-                risks.slice(0, 9).forEach((scenario, idx) => {
+                risks.slice(0, 9).forEach((scenario) => {
                     const bullet = document.createElement('button');
                     bullet.type = 'button';
                     bullet.className = `qa-overview-bullet ${scenario.id === state.data.selectedId ? 'active' : ''}`;
-                    bullet.textContent = String(idx + 1);
+                    bullet.textContent = String(rankingByScenarioId.get(scenario.id) || '');
                     bullet.title = scenario.text;
                     bullet.addEventListener('click', (event) => {
                         event.stopPropagation();


### PR DESCRIPTION
### Motivation
- Align the Quick assessment "Consolidated view" with the requested layout: title in English, show explicit row/column labels instead of axis arrows, and make bullets reflect the global risk ranking. 
- Bump the app version in the footer/payload as required by the release process.

### Description
- Updated the QA overview matrix markup in `CartoModel.html` to use an English title (`Gross risk matrix`) and explicit impact row labels and likelihood column labels (replacing axis arrows). 
- Added responsive layout and styling for the new matrix labels in `assets/css/main.css` (`.qa-overview-matrix-layout`, `.qa-overview-row-labels`, `.qa-overview-col-labels`, responsive adjustments). 
- Changed overview rendering logic in `assets/js/rms.quick-assessment.js` to compute a global ranking map (`rankingByScenarioId`) and display that ranking number in each matrix bullet; also bumped the quick-assessment payload `version` to `2.14.57`. 
- Updated page title and footer version in `CartoModel.html` to `2.14.57`.

### Testing
- Ran static JS syntax check with `node --check assets/js/rms.quick-assessment.js`, which succeeded. 
- Confirmed modified files are staged/committed (`CartoModel.html`, `assets/css/main.css`, `assets/js/rms.quick-assessment.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e632716324832e885ba9ef886ab1b4)