### PR TITLE
Fix quick assessment likelihood axis label overlap

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.57</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.58</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -883,7 +883,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.57</span>
+            <span class="app-version">Version 2.14.58</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5971,6 +5971,13 @@ tbody tr:hover {
     max-width: 520px;
 }
 
+
+.qa-matrix-surface .axis-label.x-axis {
+    bottom: 8px;
+    transform: translateX(-50%);
+    z-index: 4;
+}
+
 .qa-matrix,
 .qa-overview-matrix {
     position: absolute;

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.57',
+            version: '2.14.58',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- The Quick assessment X-axis label (`Likelihood`) was being pushed outside the matrix by a global translation and visually overlapped by the container border, so the label needs to be kept inside the box; the footer version has been bumped to `2.14.58`.

### Description
- Add a targeted CSS rule (`.qa-matrix-surface .axis-label.x-axis`) to place the X-axis label inside the matrix (`bottom: 8px`, `transform: translateX(-50%)`, `z-index: 4`) and update version strings to `2.14.58` in `CartoModel.html` (page title and footer) and `assets/js/rms.quick-assessment.js` (`version`).

### Testing
- Ran `rg -n "2\.14\.58|2\.14\.57" CartoModel.html assets/js/rms.quick-assessment.js assets/css/main.css` to confirm version occurrences were updated (success).
- Verified the diff with `git diff -- assets/css/main.css CartoModel.html assets/js/rms.quick-assessment.js` and checked repository status with `git status --short` to confirm the intended changes are present and committed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e634e85fc0832e978bba7da3cbcfe8)