### PR TITLE
Fix Net Risk Matrix Y-axis overflow and bump version to 2.14.59

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -883,7 +883,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.58</span>
+            <span class="app-version">Version 2.14.59</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -547,6 +547,10 @@ body.feedback-mode-paused .feedback-panel * {
     justify-content: center;
 }
 
+.matrix-container[data-view="net"] .matrix-wrapper {
+    padding-left: 5.5rem;
+}
+
 .matrix {
     position: relative;
     width: min(100%, 520px);
@@ -1531,7 +1535,7 @@ body.feedback-mode-paused .feedback-panel * {
 }
 
 .matrix-container[data-view="net"] .axis-label.y-axis {
-    left: -8.5rem;
+    left: -6.75rem;
 }
 
 .axis-label.y-axis .axis-arrow {

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.58',
+            version: '2.14.59',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- The Net Risk Matrix left Y-axis label (`Gross risk level`) could be rendered outside the visible card because of a large negative horizontal offset in the net view, so the layout needed a small left-padding and reduced offset to keep the label inside the frame. 
- The project version in the footer and quick-assessment state must be bumped for each task, so the displayed version was updated to `2.14.59`.

### Description
- Added a dedicated left padding for the net matrix area with `.matrix-container[data-view="net"] .matrix-wrapper { padding-left: 5.5rem; }` in `assets/css/main.css` to provide room for the Y-axis label. 
- Reduced the horizontal offset for the Y-axis in the net view by changing `.matrix-container[data-view="net"] .axis-label.y-axis { left: -8.5rem; }` to `left: -6.75rem` in `assets/css/main.css`. 
- Bumped the application version to `2.14.59` in the UI footer (`CartoModel.html`) and in the quick-assessment state (`assets/js/rms.quick-assessment.js`).

### Testing
- Ran `node --check assets/js/rms.quick-assessment.js` to validate JavaScript syntax, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e635f6a8d8832e883787f80a72346f)