### PR TITLE
Align quick assessment scales + English legends (v2.14.60)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -374,7 +374,7 @@
                 <div class="content-area quick-assessment-content">
                     <div class="qa-subtabs">
                         <button type="button" class="qa-subtab active" data-qa-view="scenarios" id="qaSubtabScenarios">1. Scenario loading</button>
-                        <button type="button" class="qa-subtab" data-qa-view="assessment" id="qaSubtabAssessment">2. Cotation</button>
+                        <button type="button" class="qa-subtab" data-qa-view="assessment" id="qaSubtabAssessment">2. Assessment</button>
                         <button type="button" class="qa-subtab" data-qa-view="overview" id="qaSubtabOverview">3. Consolidated view</button>
                     </div>
 
@@ -418,26 +418,26 @@
                                 <h4 id="qaRawDetailTitle">Gross risk details</h4>
                                 <div class="qa-risk-calculation" id="qaRiskCalculation">P1 × I1 = 1 (Low)</div>
                                 <div class="qa-risk-block">
-                                    <h5 id="qaProbabilityTitle">Probability 1 - Rare</h5>
-                                    <p id="qaProbabilityDetail">Event has not happened yet and remains unlikely in the coming year.</p>
+                                    <h5 id="qaProbabilityTitle">Probability 1 - Unlikely</h5>
+                                    <p id="qaProbabilityDetail">Event has not occurred in the past 5 years. Event not expected to occur in the next 5 years.</p>
                                 </div>
                                 <div class="qa-risk-block">
-                                    <h5 id="qaImpactTitle">Impact 1 - Minor</h5>
+                                    <h5 id="qaImpactTitle">Impact 1 - Low</h5>
                                     <ul id="qaImpactDetail" class="qa-impact-list"></ul>
                                 </div>
                                 <div class="qa-legend" id="qaRawLegend">P1 × I1 = 1 (Low)</div>
-                                <h4 id="qaAggravatingTitle">Facteurs aggravants</h4>
+                                <h4 id="qaAggravatingTitle">Aggravating factors</h4>
                                 <div id="qaAggravatingFactors" class="qa-aggravating-list"></div>
                             </div>
 
                             <div class="qa-card qa-card-controls">
                                 <label class="form-label" id="qaEffectivenessLabel" for="qaEffectiveness">Control effectiveness</label>
                                 <input type="range" id="qaEffectiveness" min="0" max="75" step="25">
-                                <div class="form-helper" id="qaEffectivenessLegend">0% - Inefficace</div>
+                                <div class="form-helper" id="qaEffectivenessLegend">0% - Ineffective</div>
                             </div>
 
                             <div class="qa-card qa-card-comment">
-                                <label class="form-label" id="qaCommentLabel" for="qaComment">Commentaire</label>
+                                <label class="form-label" id="qaCommentLabel" for="qaComment">Comment</label>
                                 <textarea id="qaComment" class="form-textarea" rows="4" placeholder="Ajoutez vos observations..."></textarea>
                                 <div class="qa-nav-actions">
                                     <button class="btn btn-secondary" type="button" id="qaPrevBtn">← Previous scenario</button>
@@ -883,7 +883,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.59</span>
+            <span class="app-version">Version 2.14.60</span>
         </footer>
     </div>
 

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -18,57 +18,57 @@
     ];
     const PROBABILITY_DETAILS = {
         1: {
-            title: 'Probability 1 - Rare',
-            description: 'Event has not happened yet and remains unlikely in the coming year.'
+            title: 'Probability 1 - Unlikely',
+            description: 'Event has not occurred in the past 5 years. Event not expected to occur in the next 5 years.'
         },
         2: {
-            title: 'Probability 2 - Possible',
-            description: 'Event has happened in isolated situations and could recur.'
+            title: 'Probability 2 - Moderately likely',
+            description: 'Event that has occurred once in the past 5 years. Event that may occur once in the next 5 years.'
         },
         3: {
             title: 'Probability 3 - Likely',
-            description: 'Event happened at least once in the past year or is expected to happen.'
+            description: 'Event that has occurred once in the past year. Event that may occur once in the coming year.'
         },
         4: {
             title: 'Probability 4 - Very likely',
-            description: 'Event happened multiple times and is expected to recur regularly.'
+            description: 'Event that occurred several times in the past year. Event expected to occur once or more times in the coming year.'
         }
     };
     const IMPACT_DETAILS = {
         1: {
-            title: 'Impact 1 - Minor',
+            title: 'Impact 1 - Low',
             points: [
-                'Financial: below €50k',
-                'Legal: no significant sanction',
-                'Reputation: limited local visibility',
-                'Operational: minimal disruption'
+                'Financial (base): < 300K€',
+                'Legal: internal disciplinary action against an employee',
+                'Reputational: no impact, internal or local external (e.g., partners); disruption limited to a few days',
+                'Operational: little or no disruption; slowdown in operations'
             ]
         },
         2: {
-            title: 'Impact 2 - Significant',
+            title: 'Impact 2 - Moderate',
             points: [
-                'Financial: €50k to €500k',
-                'Legal: formal warning or moderate sanction',
-                'Reputation: local media exposure',
-                'Operational: temporary disruption'
+                'Financial (base): [300K ; 3M€[',
+                'Legal: legal or administrative proceedings involving an individual employee',
+                'Reputational: regional external impact; disruption limited to a few weeks',
+                'Operational: minor disruptions; temporary loss of business or contracts'
             ]
         },
         3: {
-            title: 'Impact 3 - Severe',
+            title: 'Impact 3 - High',
             points: [
-                'Financial: €500k to €5m',
-                'Legal: major sanction or legal settlement',
-                'Reputation: national visibility and trust erosion',
-                'Operational: major delays or loss of business'
+                'Financial (base): [3M€ ; 30M€[',
+                'Legal: sanctions at the affiliate level; Judicial Public Interest Agreement (CJIP)',
+                'Reputational: national external impact (e.g., Department of Health); national media crisis; impact lasting several months',
+                'Operational: significant disruptions; permanent loss of business or contracts'
             ]
         },
         4: {
             title: 'Impact 4 - Critical',
             points: [
-                'Financial: above €5m',
-                'Legal: criminal exposure or exceptional sanction',
-                'Reputation: sustained national crisis',
-                'Operational: lasting business interruption'
+                'Financial (base): ≥ 30M€',
+                'Legal: group-wide sanctions; criminal conviction',
+                'Reputational: international external impact (e.g., EMA, FDA, etc.); international media crisis; long-term damage lasting several years',
+                'Operational: cessation of operations'
             ]
         }
     };
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.59',
+            version: '2.14.60',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- Ensure the quick-assessment uses the exact same probability and impact scale as risk creation so scores are consistent across the app. 
- Replace French UI labels/legends in the quick-assessment panel with the provided English wording. 
- Bump the visible application version in the footer to reflect the change as required by the release process.

### Description
- Updated probability descriptions (`PROBABILITY_DETAILS`) and impact criteria (`IMPACT_DETAILS`) in `assets/js/rms.quick-assessment.js` to match the risk-creation scale and the provided English wording. 
- Switched quick-assessment UI labels in `CartoModel.html` to English (tab label `Assessment`, `Aggravating factors`, effectiveness legend `0% - Ineffective`, `Comment`, etc.). 
- Incremented the quick-assessment stored `version` and the footer display from `2.14.59` to `2.14.60` in `assets/js/rms.quick-assessment.js` and `CartoModel.html`. 
- Modified files: `assets/js/rms.quick-assessment.js` and `CartoModel.html`.

### Testing
- Ran `node --check assets/js/rms.quick-assessment.js` and it completed successfully. 
- Verified version and content changes using `rg` searches for `Version 2.14.` and `version: '2.14.` which show the new `2.14.60` value. 
- Reviewed the produced diff with `git diff` to confirm intended edits. 
- Changes were committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e644e57b98832e944db959db3cf6ac)