### PR TITLE
Align net/gross matrix layout and English matrix labeling

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -585,7 +585,6 @@
                             <div class="matrix-wrapper">
                                 <div class="matrix">
                                     <div class="matrix-grid" id="matrixGridNet"></div>
-                                    <div class="matrix-net-row-labels" id="matrixNetRowLabels"></div>
                                     <div class="matrix-net-col-labels" id="matrixNetColLabels"></div>
                                     <div class="axis-label x-axis">Control effectiveness →</div>
                                     <div class="axis-label y-axis">
@@ -883,7 +882,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.61</span>
+            <span class="app-version">Version 2.14.62</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -514,6 +514,7 @@ body.feedback-mode-paused .feedback-panel * {
     flex-direction: column;
     gap: 24px;
     margin-bottom: 30px;
+    align-items: stretch;
 }
 
 .matrix-container.active-view {
@@ -545,10 +546,11 @@ body.feedback-mode-paused .feedback-panel * {
     align-items: flex-start;
     flex-wrap: wrap;
     justify-content: center;
+    padding-left: 0;
 }
 
 .matrix-container[data-view="net"] .matrix-wrapper {
-    padding-left: 5.5rem;
+    padding-left: 0;
 }
 
 .matrix {

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -7224,18 +7224,6 @@ class RiskManagementSystem {
                     netGrid.appendChild(cell);
                 });
             });
-
-            const rowLabels = document.getElementById('matrixNetRowLabels');
-            if (rowLabels) {
-                rowLabels.innerHTML = '';
-                brutLevels.forEach(level => {
-                    const label = document.createElement('div');
-                    label.className = 'matrix-net-row-label';
-                    label.innerHTML = `${level.label}<span>${level.range}</span>`;
-                    rowLabels.appendChild(label);
-                });
-            }
-
             const colLabels = document.getElementById('matrixNetColLabels');
             if (colLabels) {
                 colLabels.innerHTML = '';
@@ -7262,12 +7250,12 @@ class RiskManagementSystem {
                 gridId: 'matrixGridBrut',
                 probKey: 'probBrut',
                 impactKey: 'impactBrut',
-                label: 'Risque brut',
+                label: 'Gross risk',
                 mode: 'brut'
             },
             net: {
                 gridId: 'matrixGridNet',
-                label: 'Risque net',
+                label: 'Net risk',
                 mode: 'net'
             }
         };
@@ -7357,9 +7345,9 @@ class RiskManagementSystem {
                     const formattedNet = Number.isFinite(netInfo.score)
                         ? netInfo.score.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
                         : '0';
-                    tooltipSegments.push(`Brut ${formattedBrut} → Net ${formattedNet}`);
-                    tooltipSegments.push(`Réduction ${formatMitigationCoefficient(netInfo.coefficient)} (${netInfo.label})`);
-                    tooltipSegments.push(`Niveau brut : ${severityLabelMap[brutLevel] || brutLevel}`);
+                    tooltipSegments.push(`Gross ${formattedBrut} → Net ${formattedNet}`);
+                    tooltipSegments.push(`Reduction ${formatMitigationCoefficient(netInfo.coefficient)} (${netInfo.label})`);
+                    tooltipSegments.push(`Gross level: ${severityLabelMap[brutLevel] || brutLevel}`);
 
                     point.title = tooltipSegments.join(' • ');
                     point.textContent = viewSymbols[viewKey] || '';
@@ -7616,13 +7604,13 @@ class RiskManagementSystem {
                 titleId: 'riskDetailsTitleBrut',
                 probKey: 'probBrut',
                 impactKey: 'impactBrut',
-                title: 'Risques bruts triés par score',
+                title: 'Gross risks ranked by score',
                 mode: 'brut'
             },
             net: {
                 containerId: 'riskDetailsListNet',
                 titleId: 'riskDetailsTitleNet',
-                title: 'Risques nets triés par score',
+                title: 'Net risks ranked by score',
                 mode: 'net'
             }
         };
@@ -7670,8 +7658,8 @@ class RiskManagementSystem {
 
             if (!scoredRisks.length) {
                 const message = baseRisks.length
-                    ? 'No risk matches the filters appliqués.'
-                    : 'No risk recorded. Ajoutez un risque pour visualiser les détails ici.';
+                    ? 'No risk matches the active filters.'
+                    : 'No risk recorded. Add a risk to view details here.';
 
                 container.innerHTML = `
                     <div class="matrix-description-empty" style="text-align: center; padding: 16px 12px;">


### PR DESCRIPTION
### Motivation
- Remove the net-matrix dependency on a left-hand row-label column and ensure the gross and net matrices share identical vertical alignment without relying on extra DOM labels.
- Standardize matrix labels, tooltips and empty-state messages to English for a consistent UI experience.
- Bump the UI version footer to reflect the change.

### Description
- Removed the `<div class="matrix-net-row-labels" id="matrixNetRowLabels"></div>` node from the net matrix markup in `CartoModel.html` and updated the footer version to `Version 2.14.62`.
- Deleted the JS block that generated `matrixNetRowLabels` in `assets/js/rms.core.js` and replaced French labels/strings with English equivalents used in matrix tooltips and risk lists (`Gross risk`, `Net risk`, `Gross … → Net …`, `Reduction …`, `Gross level: …`, `Gross risks ranked by score`, `Net risks ranked by score`, and empty messages).
- Adjusted CSS in `assets/css/main.css` for `.matrix-dual-layout`, `.matrix-wrapper`, and `.matrix-container[data-view="net"] .matrix-wrapper` to remove the left padding and add `align-items: stretch` so net and gross matrices vertically align without a lateral label column.
- Files changed: `CartoModel.html`, `assets/js/rms.core.js`, `assets/css/main.css` (footer version updated to `2.14.62`).

### Testing
- Ran `git diff --check` with no issues found (success).
- Ran `node --check assets/js/rms.core.js` to validate JS syntax with no errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65163f6cc832ea14bfda596091f46)