### PR TITLE
Remove duplicate quick-assessment legend and centralize P × I display (version 2.14.63)

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -425,7 +425,6 @@
                                     <h5 id="qaImpactTitle">Impact 1 - Low</h5>
                                     <ul id="qaImpactDetail" class="qa-impact-list"></ul>
                                 </div>
-                                <div class="qa-legend" id="qaRawLegend">P1 × I1 = 1 (Low)</div>
                                 <h4 id="qaAggravatingTitle">Aggravating factors</h4>
                                 <div id="qaAggravatingFactors" class="qa-aggravating-list"></div>
                             </div>
@@ -882,7 +881,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.62</span>
+            <span class="app-version">Version 2.14.63</span>
         </footer>
     </div>
 

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -364,7 +364,6 @@
         renderAggravatingFactors(scenario);
 
         if (!scenario) {
-            dom.rawLegend.textContent = 'P1 × I1 = 1 (Low)';
             dom.riskCalculation.textContent = 'P1 × I1 = 1 (Low)';
             dom.probabilityTitle.textContent = PROBABILITY_DETAILS[1].title;
             dom.probabilityDetail.textContent = PROBABILITY_DETAILS[1].description;
@@ -384,7 +383,6 @@
         const impact = clampMatrixValue(scenario.raw?.impact);
         const score = prob * impact;
         const riskLegend = `P${prob} × I${impact} = ${score} (${scoreLabel(score)})`;
-        dom.rawLegend.textContent = riskLegend;
         dom.riskCalculation.textContent = riskLegend;
         dom.probabilityTitle.textContent = PROBABILITY_DETAILS[prob].title;
         dom.probabilityDetail.textContent = PROBABILITY_DETAILS[prob].description;
@@ -610,7 +608,6 @@
         dom.currentScenario = document.getElementById('qaCurrentScenario');
         dom.duplicateBtn = document.getElementById('qaDuplicateBtn');
         dom.deleteBtn = document.getElementById('qaDeleteBtn');
-        dom.rawLegend = document.getElementById('qaRawLegend');
         dom.riskCalculation = document.getElementById('qaRiskCalculation');
         dom.probabilityTitle = document.getElementById('qaProbabilityTitle');
         dom.probabilityDetail = document.getElementById('qaProbabilityDetail');


### PR DESCRIPTION
### Motivation
- Eliminate a duplicated visual legend in the Quick assessment panel to avoid redundant UI and potential JS errors when the extra element is missing.
- Keep a single authoritative DOM element for the `P × I` formula to simplify rendering logic and maintenance.
- Bump the app footer version after the change as required by project policy.

### Description
- Removed the HTML node `<div class="qa-legend" id="qaRawLegend">…</div>` from `CartoModel.html` and updated the footer version to `2.14.63`.
- Stopped querying the removed element by removing `dom.rawLegend = document.getElementById('qaRawLegend')` from `assets/js/rms.quick-assessment.js`.
- Removed all assignments to `dom.rawLegend.textContent` inside `renderAssessment` so only `#qaRiskCalculation` is used to display the `P × I` formula.
- Ensures the no-scenario branch updates only `dom.riskCalculation` (the single source of truth) to avoid touching removed nodes.

### Testing
- Ran `node --check assets/js/rms.quick-assessment.js` which completed successfully.
- Ran a search `rg -n "qaRawLegend|rawLegend" CartoModel.html assets/js/rms.quick-assessment.js` which returned no references to the removed symbol.
- Confirmed automated checks show no syntax errors and no remaining references to `qaRawLegend` (both checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65547c0f4832e912addc4b917589c)