### PR TITLE
Replace French select/deselect labels with English and bump footer to 2.14.65

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -881,7 +881,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.64</span>
+            <span class="app-version">Version 2.14.65</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -3284,7 +3284,7 @@ class RiskManagementSystem {
             const selectButton = document.createElement('button');
             selectButton.type = 'button';
             selectButton.className = 'btn btn-outline btn-small';
-            selectButton.textContent = 'Tout sélectionner';
+            selectButton.textContent = 'Select all';
             selectButton.addEventListener('click', () => {
                 if (typeof selectRiskCountryColumn === 'function' && column?.key) {
                     selectRiskCountryColumn(column.key);
@@ -3295,7 +3295,7 @@ class RiskManagementSystem {
             const clearButton = document.createElement('button');
             clearButton.type = 'button';
             clearButton.className = 'btn btn-outline btn-small';
-            clearButton.textContent = 'Tout désélectionner';
+            clearButton.textContent = 'Deselect all';
             clearButton.addEventListener('click', () => {
                 if (typeof deselectRiskCountryColumn === 'function' && column?.key) {
                     deselectRiskCountryColumn(column.key);


### PR DESCRIPTION
### Motivation
- Avoid mixed FR/EN UI by replacing French inline labels `Tout sélectionner` / `Tout désélectionner` used in dynamic JS with English equivalents and update the app footer version as requested to `2.14.65`.

### Description
- Replaced `Tout sélectionner` with `Select all` and `Tout désélectionner` with `Deselect all` in `assets/js/rms.core.js` (risk-country column controls). 
- Updated footer version from `Version 2.14.64` to `Version 2.14.65` in `CartoModel.html` as required by the task.
- Verified the admin multi-select toolbar in `CartoModel.html` already uses the English `Select all` / `Deselect all` labels to avoid mixing languages.

### Testing
- Searched the codebase for French select/deselect variants using `rg` and confirmed occurrences were replaced successfully (no remaining `Tout sélectionner` / `Tout désélectionner` in scanned files). — succeeded.
- Ran `git diff` to review changes to `assets/js/rms.core.js` and `CartoModel.html` and then committed the modifications; commit succeeded.
- Re-scanned files for the new `Select all` / `Deselect all` strings and the updated footer `Version 2.14.65` using `rg` to confirm the final state — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6579ad934832eb56d63444cf9ced2)