### PR TITLE
Disable remaining localStorage usage and bump app version to 2.14.71

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.70</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.71</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.70</span>
+            <span class="app-version">Version 2.14.71</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -10503,7 +10503,7 @@ class RiskManagementSystem {
     }
 
     loadMentionArchive() {
-        if (typeof localStorage === 'undefined') {
+        if (!RMS_LOCAL_STORAGE_ENABLED || typeof localStorage === 'undefined') {
             return new Set();
         }
 
@@ -10531,7 +10531,7 @@ class RiskManagementSystem {
     }
 
     saveMentionArchive() {
-        if (typeof localStorage === 'undefined') {
+        if (!RMS_LOCAL_STORAGE_ENABLED || typeof localStorage === 'undefined') {
             return;
         }
 


### PR DESCRIPTION
### Motivation
- Stop the last active `localStorage` usage for mention archives so persistence respects the global `RMS_LOCAL_STORAGE_ENABLED` flag and can be fully disabled. 
- Align visible app version with the change request to indicate a new release after this task. 
- Update the public-facing version number in the footer as required by the release/update policy. 

### Description
- Guarded `loadMentionArchive()` with `RMS_LOCAL_STORAGE_ENABLED` so it returns an empty `Set` when persistence is disabled in `assets/js/rms.core.js`. 
- Guarded `saveMentionArchive()` with `RMS_LOCAL_STORAGE_ENABLED` so it no-ops when persistence is disabled in `assets/js/rms.core.js`. 
- Bumped the application version string from `2.14.70` to `2.14.71` in `CartoModel.html` (page `<title>` and footer `.app-version`). 
- Changes were staged and committed to the repository. 

### Testing
- Ran `node --check assets/js/rms.core.js` and it completed successfully without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71320946c832e93d5f71bfc48a0ed)