### PR TITLE
Ajouter la colonne Entities à l'export XLSX des risques

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.71</span>
+            <span class="app-version">Version 2.14.72</span>
         </footer>
     </div>
 

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -1786,6 +1786,9 @@ function exportReportsRisksXlsx() {
         const tiers = Array.isArray(risk?.tiers)
             ? risk.tiers.map((item) => mapToLabel(item, rms?.config?.tiers)).filter(Boolean).join(', ')
             : '';
+        const entities = Array.isArray(risk?.paysExposes)
+            ? risk.paysExposes.map((item) => mapToLabel(item, rms?.config?.countries)).filter(Boolean).join(', ')
+            : '';
 
         const probBrut = Number(risk?.probBrut) || 0;
         const impactBrut = Number(risk?.impactBrut) || 0;
@@ -1825,6 +1828,7 @@ function exportReportsRisksXlsx() {
             'Statut du risque': riskStatus || '',
             'Type de corruption': corruptionLabel || '',
             'Tiers': tiers,
+            'Entities': entities,
             'Scénario': risk?.description || risk?.titre || '',
             'Probabilité brut': probBrut || '',
             'Impact brut': impactBrut || '',
@@ -1873,9 +1877,10 @@ function exportReportsRisksXlsx() {
             }
 
             worksheet['!cols'] = [
-                { wch: 18 }, { wch: 24 }, { wch: 24 }, { wch: 45 }, { wch: 16 },
-                { wch: 14 }, { wch: 20 }, { wch: 18 }, { wch: 26 }, { wch: 18 },
-                { wch: 22 }, { wch: 32 }, { wch: 25 }, { wch: 20 }, { wch: 20 }
+                { wch: 18 }, { wch: 24 }, { wch: 24 }, { wch: 28 }, { wch: 45 },
+                { wch: 16 }, { wch: 14 }, { wch: 20 }, { wch: 18 }, { wch: 26 },
+                { wch: 18 }, { wch: 22 }, { wch: 32 }, { wch: 25 }, { wch: 20 },
+                { wch: 20 }
             ];
 
             const filename = `report-risques-${new Date().toISOString().slice(0, 10)}.xlsx`;


### PR DESCRIPTION
### Motivation
- Permettre l'export des entités concernées par chaque risque dans le fichier XLSX d'export pour obtenir un rapport plus complet et lisible.
- Respecter la consigne de mettre à jour le numéro de version affiché dans le footer lors de toute modification livrée.

### Description
- Ajout d'un champ `Entities` dans le payload CSV/XLSX généré par la fonction `exportReportsRisksXlsx` en mappant `risk.paysExposes` vers les libellés configurés via `rms.config.countries` pour des valeurs lisibles (`assets/js/rms.integrations.js`).
- Ajustement des largeurs de colonnes XLSX (`worksheet['!cols']`) pour intégrer la nouvelle colonne sans casser la mise en forme (`assets/js/rms.integrations.js`).
- Mise à jour de la version dans le footer de l'application de `Version 2.14.71` à `Version 2.14.72` (`CartoModel.html`).

### Testing
- Exécution de `git diff --check` pour vérifier l'absence d'erreurs de diff, réussite.
- Vérification syntaxique du fichier modifié avec `node --check assets/js/rms.integrations.js`, réussite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e71482129c832eb1af38ffed500d8d)