### PR TITLE
Risk Register: show entities & aggravated score, add entity chips filter, include risk ID in Reports export, bump version to 2.14.73

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.71</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.73</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -657,6 +657,10 @@
                                 <option value="">All statuses</option>
                             </select>
                         </div>
+                        <div class="filter-group">
+                            <label class="filter-label" for="risksEntityFilterChips">Entities</label>
+                            <div id="risksEntityFilterChips" class="filter-chip-group" aria-label="Filter risks by entities"></div>
+                        </div>
                         <div class="search-box filter-group">
                             <label class="filter-label" for="risksSearchInput">Search</label>
                             <input type="search" class="search-input" id="risksSearchInput" data-risk-filter="search" placeholder="🔍 Search a risk..." oninput="searchRisks(this.value, this)">
@@ -668,14 +672,14 @@
                                 <tr>
                                     <th>ID</th>
                                     <th>Description</th>
-                                    <th>Process</th>
-                                    <th>Sub-process</th>
                                     <th>Type</th>
                                     <th>Tiers</th>
+                                    <th>Entities</th>
                                     <th>Gross score</th>
+                                    <th>Aggravated score</th>
                                     <th>Net score</th>
                                     <th>Status</th>
-                                    <th>Actions</th>
+                                    <th>Action Plan</th>
                                 </tr>
                             </thead>
                             <tbody id="risksTableBody">
@@ -884,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.72</span>
+            <span class="app-version">Version 2.14.73</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -3540,33 +3540,34 @@ class RiskManagementSystem {
     }
 
     renderMatrixEntityFilterChips() {
-        const container = document.getElementById('matrixEntityFilterChips');
-        if (!container) {
-            return;
-        }
-
         const options = Array.isArray(this.config?.countries) ? this.config.countries : [];
         const selected = new Set(Array.isArray(this.filters?.entity) ? this.filters.entity : []);
-        container.innerHTML = '';
-
-        options.forEach(entry => {
-            if (!entry || entry.value == null) {
+        ['matrixEntityFilterChips', 'risksEntityFilterChips'].forEach((containerId) => {
+            const container = document.getElementById(containerId);
+            if (!container) {
                 return;
             }
-            const value = String(entry.value);
-            const label = entry.label || value;
-            const chip = document.createElement('button');
-            chip.type = 'button';
-            chip.className = 'btn btn-outline btn-small';
-            chip.textContent = label;
-            chip.classList.toggle('btn-primary', selected.has(value));
-            chip.classList.toggle('btn-outline', !selected.has(value));
-            chip.addEventListener('click', () => {
-                if (typeof window.toggleEntityFilterChip === 'function') {
-                    window.toggleEntityFilterChip(value);
+            container.innerHTML = '';
+
+            options.forEach(entry => {
+                if (!entry || entry.value == null) {
+                    return;
                 }
+                const value = String(entry.value);
+                const label = entry.label || value;
+                const chip = document.createElement('button');
+                chip.type = 'button';
+                chip.className = 'btn btn-outline btn-small';
+                chip.textContent = label;
+                chip.classList.toggle('btn-primary', selected.has(value));
+                chip.classList.toggle('btn-outline', !selected.has(value));
+                chip.addEventListener('click', () => {
+                    if (typeof window.toggleEntityFilterChip === 'function') {
+                        window.toggleEntityFilterChip(value);
+                    }
+                });
+                container.appendChild(chip);
             });
-            container.appendChild(chip);
         });
     }
 
@@ -9260,8 +9261,12 @@ class RiskManagementSystem {
                 ? getRiskNetInfo(risk)
                 : { score: (Number(risk?.probNet) || 0) * (Number(risk?.impactNet) || 0), coefficient: 0, reduction: 0, label: '' };
             const netScore = netInfo.score;
+            const aggravatedBrutScore = Number.isFinite(netInfo.brutScore) ? netInfo.brutScore : brutScore;
             const brutLabel = Number.isFinite(brutScore)
                 ? brutScore.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
+                : '0';
+            const aggravatedBrutLabel = Number.isFinite(aggravatedBrutScore)
+                ? aggravatedBrutScore.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
                 : '0';
             const netLabel = Number.isFinite(netScore)
                 ? netScore.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
@@ -9275,6 +9280,22 @@ class RiskManagementSystem {
             const typeLabel = resolveLabel(typeMap, risk.typeCorruption);
             const tierLabels = Array.isArray(risk.tiers)
                 ? risk.tiers.map(tier => resolveLabel(tierMap, tier))
+                : [];
+            const entityLabels = Array.isArray(risk.paysExposes)
+                ? risk.paysExposes.map(entity => this.getCountryLabel(entity) || entity).filter(Boolean)
+                : [];
+            const actionPlanTitles = Array.isArray(this.actionPlans)
+                ? this.actionPlans
+                    .filter(plan => {
+                        if (!plan) return false;
+                        const directRefs = Array.isArray(risk.actionPlans) ? risk.actionPlans : [];
+                        const isDirect = directRefs.some(ref => idsEqual(typeof ref === 'object' ? ref?.id : ref, plan.id));
+                        const linkedRisks = Array.isArray(plan.risks) ? plan.risks : [];
+                        const isLinked = linkedRisks.some(linkedRiskId => idsEqual(linkedRiskId, risk.id));
+                        return isDirect || isLinked;
+                    })
+                    .map(plan => plan.title || plan.name || `#${plan.id}`)
+                    .filter(Boolean)
                 : [];
             const riskStatusValue = this.normalizeStatusValue(
                 'risk',
@@ -9292,20 +9313,14 @@ class RiskManagementSystem {
                 <tr>
                     <td>#${risk.id}</td>
                     <td>${risk.description}</td>
-                    <td>${this.getProcessLabel(risk.processus)}</td>
-                    <td>${this.getSubProcessLabel(risk.processus, risk.sousProcessus) || ''}</td>
                     <td>${typeLabel}</td>
                     <td>${tierLabels.join(', ')}</td>
+                    <td>${entityLabels.join(', ')}</td>
                     <td>${brutLabel}</td>
+                    <td>${aggravatedBrutLabel}</td>
                     <td title="Reduction ${reductionLabel}${effectivenessLabel}">${netLabel}</td>
                     <td><span class="table-badge badge-${riskBadgeClass}">${riskStatusLabel || 'Not defined'}</span></td>
-                    <td class="table-actions-cell">
-                        <div class="table-actions">
-                            <button class="action-btn" title="Dupliquer" onclick="rms.duplicateRisk(${JSON.stringify(risk.id)})">📄</button>
-                            <button class="action-btn" onclick="rms.editRisk(${JSON.stringify(risk.id)})">✏️</button>
-                            <button class="action-btn" onclick="rms.deleteRisk(${JSON.stringify(risk.id)})">🗑️</button>
-                        </div>
-                    </td>
+                    <td>${actionPlanTitles.join(' | ')}</td>
                 </tr>
             `;
         }).join('');

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -1825,6 +1825,7 @@ function exportReportsRisksXlsx() {
         }).filter(Boolean).join(' | ');
 
         return {
+            'ID du risque': risk?.id ?? '',
             'Statut du risque': riskStatus || '',
             'Type de corruption': corruptionLabel || '',
             'Tiers': tiers,


### PR DESCRIPTION
### Motivation
- Afficher dans l’onglet Risk Register les colonnes demandées et permettre le tri/filtre par entités avec le système de chips.  
- Inclure l’ID du risque en première colonne dans l’export des risques depuis l’onglet Reports.  
- Harmoniser la version affichée dans l’UI (footer et title) conformément à la règle de versionnement en footer (nouvelle version: `2.14.73`).

### Description
- Ajout dans `CartoModel.html` de la zone de chips pour le filtre entités dans la barre de filtres du registre et modification des en-têtes du tableau Risk Register pour afficher `ID, Description, Type, Tiers, Entities, Gross score, Aggravated score, Net score, Status, Action Plan` et mise à jour de la version UI à `2.14.73`.
- Extension de `renderMatrixEntityFilterChips()` dans `assets/js/rms.core.js` pour rendre les chips à la fois dans la matrice et dans le registre (`matrixEntityFilterChips` et `risksEntityFilterChips`).
- Mise à jour du rendu des lignes de `updateRisksList()` dans `assets/js/rms.core.js` pour afficher les entités, le score brut aggravé (`aggravatedBrutLabel`) et les titres des plans d’action liés dans la colonne Action Plan.
- Ajout de la clé `'ID du risque'` en première colonne dans l’objet retourné par `exportReportsRisksXlsx()` dans `assets/js/rms.integrations.js` pour inclure l’ID dans l’export XLSX.

### Testing
- Exécuté `node --check assets/js/rms.core.js` et la vérification a réussi.  
- Exécuté `node --check assets/js/rms.integrations.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e715dea818832ea79af7333d70f544)