### PR TITLE
Improve CSV parsing robustness and bump app version to 2.14.74

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.73</span>
+            <span class="app-version">Version 2.14.74</span>
         </footer>
     </div>
 

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -1535,18 +1535,60 @@ function csvSplitLine(line, delimiter = ';') {
 }
 
 function parseCsvText(content) {
-    const lines = String(content || '')
+    const normalized = String(content || '')
         .replace(/\r\n/g, '\n')
-        .replace(/\r/g, '\n')
-        .split('\n')
-        .map(line => line.trim())
-        .filter(Boolean);
-    if (!lines.length) {
+        .replace(/\r/g, '\n');
+
+    const rows = [];
+    let currentRow = [];
+    let currentCell = '';
+    let inQuotes = false;
+
+    for (let index = 0; index < normalized.length; index += 1) {
+        const char = normalized[index];
+
+        if (inQuotes) {
+            if (char === '"') {
+                if (normalized[index + 1] === '"') {
+                    currentCell += '"';
+                    index += 1;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                currentCell += char;
+            }
+            continue;
+        }
+
+        if (char === '"') {
+            inQuotes = true;
+        } else if (char === ';') {
+            currentRow.push(currentCell);
+            currentCell = '';
+        } else if (char === '\n') {
+            currentRow.push(currentCell);
+            if (currentRow.some(cell => String(cell || '').trim() !== '')) {
+                rows.push(currentRow);
+            }
+            currentRow = [];
+            currentCell = '';
+        } else {
+            currentCell += char;
+        }
+    }
+
+    currentRow.push(currentCell);
+    if (currentRow.some(cell => String(cell || '').trim() !== '')) {
+        rows.push(currentRow);
+    }
+
+    if (!rows.length) {
         return [];
     }
-    const headers = csvSplitLine(lines[0]).map(header => String(header || '').trim());
-    return lines.slice(1).map((line) => {
-        const values = csvSplitLine(line);
+
+    const headers = rows[0].map(header => String(header || '').trim());
+    return rows.slice(1).map((values) => {
         return headers.reduce((row, header, index) => {
             row[header] = (values[index] ?? '').trim();
             return row;


### PR DESCRIPTION
### Motivation
- Fix issues with CSV import that arose from naive line-splitting, by supporting quoted fields, escaped quotes, embedded newlines and mixed newline styles.
- Bump the app version to reflect the update (`2.14.73` → `2.14.74`).

### Description
- Rewrote the `parseCsvText` implementation in `assets/js/rms.integrations.js` to use a stateful parser that normalizes CR/LF, handles quoted cells and escaped quotes, treats `;` as the delimiter, and ignores fully empty rows.
- The new parser trims headers and values and returns an array of objects keyed by header names, replacing the previous split-and-trim approach that used `csvSplitLine` on line strings.
- Updated the footer app version in `CartoModel.html` from `Version 2.14.73` to `Version 2.14.74`.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e723362670832e956f5fd40a4110ab)