### PR TITLE
Use `idsEqual` for control ID comparisons, simplify benefit-linked display, bump version to 2.14.75

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.73</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.75</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.74</span>
+            <span class="app-version">Version 2.14.75</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -532,7 +532,7 @@ function getAssignedControlsForBenefit(label) {
         if (!(assignment.avantagesIndus || []).includes(label)) {
             return null;
         }
-        const control = rms.controls.find(ctrl => ctrl.id === controlId);
+        const control = rms.controls.find(ctrl => idsEqual(ctrl.id, controlId));
         return {
             id: controlId,
             name: control?.name || `#${controlId}`
@@ -559,7 +559,7 @@ function renderBenefitFirstAssignment() {
                     : 'No linked control';
                 const linkedHtml = linkedControls.length
                     ? `<div class="benefit-first-linked-controls">
-                        ${linkedControls.map(item => `<span class="benefit-first-linked-chip">#${item.id} - ${item.name}</span>`).join('')}
+                        ${linkedControls.map(item => `<span class="benefit-first-linked-chip">${item.name}</span>`).join('')}
                     </div>`
                     : '';
                 return `
@@ -598,7 +598,7 @@ function selectRecommendedControlsForFocusedBenefit() {
     if (!label) return;
     const recommendedIds = getRecommendedControlIdsForBenefit(label);
     recommendedIds.forEach(controlId => {
-        if (!selectedControlsForRisk.includes(controlId)) {
+        if (!selectedControlsForRisk.some(id => idsEqual(id, controlId))) {
             selectedControlsForRisk.push(controlId);
         }
         const key = String(controlId);
@@ -1537,7 +1537,7 @@ function updateSelectedControlsDisplay() {
     const transverseControls = selectedControlsForRisk.map(id => {
         const assignment = controlAssignmentsForRisk[String(id)];
         if (!assignment?.transverse) return null;
-        const ctrl = rms.controls.find(c => c.id === id);
+        const ctrl = rms.controls.find(c => idsEqual(c.id, id));
         if (!ctrl) return null;
         return `<span class="transverse-control-chip">#${id} - ${ctrl.name || 'Unnamed'} <button type="button" class="transverse-control-remove-btn" onclick="removeControlFromSelection(${id})" aria-label="Remove cross-functional control #${id}">×</button></span>`;
     }).filter(Boolean);


### PR DESCRIPTION
### Motivation
- Fix inconsistent ID comparison logic when control IDs can be of different types and improve the benefit-linked controls UI by showing names instead of prefixed IDs.
- Publish a patch version bump to reflect the changes in the UI bundle.

### Description
- Replaced strict equality checks with the helper `idsEqual` for control ID comparisons in `getAssignedControlsForBenefit`, `updateSelectedControlsDisplay`, and selection logic to avoid mismatches between numeric and string IDs.
- Adjusted selection logic in `selectRecommendedControlsForFocusedBenefit` to use `some(... idsEqual ...)` when checking for already-selected controls to match the new comparison approach.
- Simplified benefit-linked control chips in the benefit-first view to display only the control `name` (removed `#id - ` prefix) for clearer UI.
- Bumped application strings in `CartoModel.html` (title and footer) to version `2.14.75`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7396c19fc832ea9627af9aef13b6a)