### PR TITLE
Retire l’affichage doublon des contrôles dans benefit-first-meta et bumps la version footer

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.75</span>
+            <span class="app-version">Version 2.14.76</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -554,9 +554,6 @@ function renderBenefitFirstAssignment() {
         <div class="benefit-first-assignment-grid">
             ${undueBenefits.map(label => {
                 const linkedControls = getAssignedControlsForBenefit(label);
-                const summary = linkedControls.length
-                    ? linkedControls.slice(0, 2).map(item => item.name).join(' • ') + (linkedControls.length > 2 ? ` • +${linkedControls.length - 2}` : '')
-                    : 'No linked control';
                 const linkedHtml = linkedControls.length
                     ? `<div class="benefit-first-linked-controls">
                         ${linkedControls.map(item => `<span class="benefit-first-linked-chip">${item.name}</span>`).join('')}
@@ -566,7 +563,6 @@ function renderBenefitFirstAssignment() {
                     <div class="benefit-first-card">
                         <div>
                             <div class="benefit-first-label">${label}</div>
-                            <div class="benefit-first-meta">${summary}</div>
                             ${linkedHtml}
                         </div>
                         <div class="benefit-first-actions">


### PR DESCRIPTION
### Motivation
- Éviter l’apparition en double des contrôles dans le résumé textuel `benefit-first-meta` lorsque les mêmes contrôles sont déjà affichés sous forme de chips dédiées. 
- Mettre à jour le numéro de version affiché dans le footer conformément à la règle de versioning présente dans le projet (footer). 

### Description
- Supprime la génération du `summary` et la ligne `<div class="benefit-first-meta">...</div>` dans `renderBenefitFirstAssignment()` afin de ne plus dupliquer l’affichage des contrôles (modification de `assets/js/rms.ui.js`).
- Bump de la version affichée dans le footer de l’application de `Version 2.14.75` à `Version 2.14.76` (modification de `CartoModel.html`).

### Testing
- Vérification syntaxique JavaScript exécutée avec `node -e "new Function(require('fs').readFileSync('assets/js/rms.ui.js','utf8')); console.log('rms.ui.js syntax OK')"` et réussie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e740f92e04832eaf4aa178350f85e0)