### PR TITLE
Close risk modal on Save and bump footer version to 2.14.77

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.76</span>
+            <span class="app-version">Version 2.14.77</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1166,6 +1166,7 @@ window.closeModal = closeModal;
 window.getSelectedActionPlansForRisk = () => selectedActionPlansForRisk;
 function saveRisk() {
     if (!rms) return;
+    let riskSaved = false;
 
     const aggravatingSelection = typeof getFormAggravatingSelection === 'function'
         ? getFormAggravatingSelection()
@@ -1271,7 +1272,7 @@ function saveRisk() {
 
             rms.saveData();
             rms.init();
-            closeModal('riskModal');
+            riskSaved = true;
             if (isIncompleteRisk) {
                 showNotification('info', 'Incomplete risk saved as draft');
             } else {
@@ -1304,7 +1305,7 @@ function saveRisk() {
 
         rms.saveData();
         rms.renderAll();
-        closeModal('riskModal');
+        riskSaved = true;
         if (isIncompleteRisk) {
             showNotification('info', 'Incomplete risk saved as draft');
         } else {
@@ -1331,6 +1332,10 @@ function saveRisk() {
 
     if (rms && typeof rms.clearUnsavedChanges === 'function') {
         rms.clearUnsavedChanges('riskForm');
+    }
+
+    if (riskSaved) {
+        closeModal('riskModal');
     }
 }
 window.saveRisk = saveRisk;


### PR DESCRIPTION
### Motivation
- Ensure that when a user creates or edits a risk and clicks `Save`, the risk creation modal reliably closes after a successful save to avoid leaving the modal open.
- Increment the app footer version as part of the change process and per project convention to reflect the update (`2.14.77`).

### Description
- Add a `riskSaved` boolean in `saveRisk()` and set it on both create and update success paths, then perform a single `closeModal('riskModal')` at the end of the function (file: `assets/js/rms.ui.js`).
- Replace the previous immediate `closeModal('riskModal')` calls with `riskSaved = true` to centralize modal closing logic (file: `assets/js/rms.ui.js`).
- Bump the footer version string from `2.14.76` to `2.14.77` (file: `CartoModel.html`).

### Testing
- Ran a JS syntax check with `node -e "new Function(require('fs').readFileSync('assets/js/rms.ui.js','utf8')); console.log('rms.ui.js syntax OK')"` which succeeded.
- Verified the repository state and committed the changes via local git commands which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7419c7614832e8120c7268da42aac)