### PR TITLE
Reset risk filters when newly created risk is hidden; bump version to 2.14.78

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.75</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.78</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.77</span>
+            <span class="app-version">Version 2.14.78</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -197,6 +197,18 @@ function toggleEntityFilterChip(entityValue) {
 }
 window.toggleEntityFilterChip = toggleEntityFilterChip;
 
+function resetRiskFilters() {
+    if (!window.rms) return;
+    rms.filters = {
+        process: '',
+        type: '',
+        status: '',
+        search: '',
+        entity: []
+    };
+    applyFilters('', '', null);
+}
+
 function syncControlFilterWidgets(filterKey, value, sourceElement) {
     const normalizedKey = typeof filterKey === 'string' ? filterKey.trim() : '';
     if (!normalizedKey) return;
@@ -1306,6 +1318,13 @@ function saveRisk() {
         rms.saveData();
         rms.renderAll();
         riskSaved = true;
+        const riskVisibleWithCurrentFilters = Array.isArray(rms.getFilteredRisks?.(rms.risks))
+            ? rms.getFilteredRisks(rms.risks).some(risk => idsEqual(risk.id, newRisk.id))
+            : true;
+        if (!riskVisibleWithCurrentFilters) {
+            resetRiskFilters();
+            showNotification('info', 'Filters have been reset to display the newly created risk');
+        }
         if (isIncompleteRisk) {
             showNotification('info', 'Incomplete risk saved as draft');
         } else {


### PR DESCRIPTION
### Motivation
- Fix a UX issue where a newly created risk could remain hidden from the "Risk Register" view when active filters excluded it.  
- Ensure the project version shown in the footer is incremented for this change (`2.14.78`).

### Description
- Added a helper `resetRiskFilters()` which clears `process/type/status/search/entity` and reapplies filters via `applyFilters`. (`assets/js/rms.ui.js`).
- After creating a risk in `saveRisk()`, check visibility with `rms.getFilteredRisks(rms.risks)` and call `resetRiskFilters()` plus `showNotification()` when the new risk is not present under current filters. (`assets/js/rms.ui.js`).
- Updated the page `<title>` and the footer `span.app-version` to `Version 2.14.78`. (`CartoModel.html`).

### Testing
- Performed static syntax checks with `node --check assets/js/rms.ui.js` and it succeeded.  
- Performed static syntax checks with `node --check assets/js/rms.core.js` and it succeeded.  
- Performed static syntax checks with `node --check assets/js/main.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7465a39b0832eb9926349ea4cf5a9)