### PR TITLE
Forcer rafraîchissement de la table des risques après save et bump version 2.14.78

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.75</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.78</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.77</span>
+            <span class="app-version">Version 2.14.78</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1316,6 +1316,7 @@ function saveRisk() {
     if (rms) {
         rms.renderRiskPoints();
         rms.updateRiskDetailsList();
+        rms.updateRisksList();
     }
 
     lastRiskData = {


### PR DESCRIPTION
### Motivation
- Résoudre un problème où un risque créé apparaissait sur la matrice mais pas dans le tableau `risksTableBody` en garantissant un rafraîchissement explicite de la liste après enregistrement.
- Maintenir la cohérence de l'interface en alignant la version affichée dans le footer et le titre sur la nouvelle version demandée.

### Description
- Ajout d'un appel explicite à `rms.updateRisksList()` dans le bloc post-save partagé de la fonction `saveRisk` pour forcer le rendu du tableau des risques (`assets/js/rms.ui.js`).
- Mise à jour du titre de la page et du texte du footer pour passer à la version `v2.14.78` / `Version 2.14.78` (`CartoModel.html`).
- Ce changement assure que le tableau de détails des risques est synchronisé après la création ou la mise à jour d'un risque.

### Testing
- Validation statique du script JavaScript réalisée avec `node --check assets/js/rms.ui.js`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e74bcef408832eae869ea303aa5a51)