### PR TITLE
Add select-all/deselect-all for Entities filters and default all-selected behavior

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.78</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.79</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.78</span>
+            <span class="app-version">Version 2.14.79</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -422,6 +422,12 @@ body.feedback-mode-paused .feedback-panel * {
     gap: 8px;
 }
 
+.filter-chip-actions {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+}
+
 .filter-label {
     font-size: 0.85em;
     color: var(--muted-text-color);

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -135,12 +135,17 @@ class RiskManagementSystem {
         this.processScoreMode = 'net';
         this.currentTab = 'dashboard';
         this.currentConfigSection = 'processManager';
+        const defaultEntityFilters = Array.isArray(this.config?.countries)
+            ? this.config.countries
+                .map(country => (country && country.value != null) ? String(country.value) : '')
+                .filter(Boolean)
+            : [];
         this.filters = {
             process: '',
             type: '',
             status: '',
             search: '',
-            entity: []
+            entity: defaultEntityFilters
         };
         this.controlFilters = {
             type: '',
@@ -3548,6 +3553,33 @@ class RiskManagementSystem {
                 return;
             }
             container.innerHTML = '';
+
+            const actions = document.createElement('div');
+            actions.className = 'filter-chip-actions';
+
+            const selectAllButton = document.createElement('button');
+            selectAllButton.type = 'button';
+            selectAllButton.className = 'btn btn-outline btn-small';
+            selectAllButton.textContent = 'Select all';
+            selectAllButton.addEventListener('click', () => {
+                if (typeof window.setAllEntityFilterChips === 'function') {
+                    window.setAllEntityFilterChips(true);
+                }
+            });
+            actions.appendChild(selectAllButton);
+
+            const deselectAllButton = document.createElement('button');
+            deselectAllButton.type = 'button';
+            deselectAllButton.className = 'btn btn-outline btn-small';
+            deselectAllButton.textContent = 'Deselect all';
+            deselectAllButton.addEventListener('click', () => {
+                if (typeof window.setAllEntityFilterChips === 'function') {
+                    window.setAllEntityFilterChips(false);
+                }
+            });
+            actions.appendChild(deselectAllButton);
+
+            container.appendChild(actions);
 
             options.forEach(entry => {
                 if (!entry || entry.value == null) {

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -197,6 +197,20 @@ function toggleEntityFilterChip(entityValue) {
 }
 window.toggleEntityFilterChip = toggleEntityFilterChip;
 
+function setAllEntityFilterChips(selectAll = true) {
+    if (!window.rms) return;
+
+    const options = Array.isArray(rms.config?.countries)
+        ? rms.config.countries
+            .map(entry => (entry && entry.value != null) ? String(entry.value) : '')
+            .filter(Boolean)
+        : [];
+
+    const next = selectAll ? options : [];
+    applyFilters('entity', next, null);
+}
+window.setAllEntityFilterChips = setAllEntityFilterChips;
+
 function syncControlFilterWidgets(filterKey, value, sourceElement) {
     const normalizedKey = typeof filterKey === 'string' ? filterKey.trim() : '';
     if (!normalizedKey) return;


### PR DESCRIPTION
### Motivation
- Provide a quick way to select or deselect all entity filters in the matrix/risks views to speed up filtering workflows.
- Make the default filters behavior treat all configured entities as selected so the initial view shows all risks (preserving the existing OR matching logic).
- Keep UI consistent by adding an action row for entity chips and ensure the app version in the footer reflects the change (`2.14.79`).

### Description
- Initialize `this.filters.entity` with all configured entity values from `this.config.countries` in `assets/js/rms.core.js` so entities are selected by default via `defaultEntityFilters`.
- Add action buttons to the entity chip render in `assets/js/rms.core.js` that call a new UI helper to `Select all` / `Deselect all` for entity chips.
- Implement `setAllEntityFilterChips(selectAll)` in `assets/js/rms.ui.js` which builds the full entity list and delegates to the existing `applyFilters('entity', ...)` pipeline.
- Add `.filter-chip-actions` CSS in `assets/css/main.css` and bump the title/footer version to `2.14.79` in `CartoModel.html`.

### Testing
- Ran `node --check assets/js/rms.core.js` and it completed with no syntax errors.
- Ran `node --check assets/js/rms.ui.js` and it completed with no syntax errors.
- Verified UI code paths invoke `rms.renderMatrixEntityFilterChips()` after filter changes so the new actions re-render chips as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e750906d94832e996ce2aab092f64d)