### PR TITLE
Fermer le modal de création de risque après sauvegarde et bump version à 2.14.80

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.79</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.80</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -888,7 +888,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.79</span>
+            <span class="app-version">Version 2.14.80</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1327,6 +1327,10 @@ function saveRisk() {
         }
     }
 
+    if (riskSaved) {
+        closeModal('riskModal');
+    }
+
     if (rms) {
         rms.renderRiskPoints();
         rms.updateRiskDetailsList();
@@ -1347,10 +1351,6 @@ function saveRisk() {
 
     if (rms && typeof rms.clearUnsavedChanges === 'function') {
         rms.clearUnsavedChanges('riskForm');
-    }
-
-    if (riskSaved) {
-        closeModal('riskModal');
     }
 }
 window.saveRisk = saveRisk;


### PR DESCRIPTION
### Motivation
- Corriger un cas où le modal de création de risque ne se fermait pas visuellement après un `saveRisk` réussi, ce qui bloquait l'expérience utilisateur.
- S'assurer que la fermeture du modal `riskModal` survient dès que le risque est bien sauvegardé afin d'éviter qu'un rendu ultérieur empêche la fermeture.
- Mettre à jour le numéro de version affiché dans le footer comme demandé; la version affichée est maintenant `2.14.80`.

### Description
- Modifier l'ordre d'exécution dans `saveRisk` en appelant `closeModal('riskModal')` immédiatement lorsque `riskSaved` est true, avant les rafraîchissements non critiques de l'UI dans `assets/js/rms.ui.js`.
- Conserver les appels de post-sauvegarde (`rms.renderRiskPoints()`, `rms.updateRiskDetailsList()`, `rms.updateRisksList()`, la mise à jour de `lastRiskData` et `rms.clearUnsavedChanges('riskForm')`) après la fermeture du modal pour préserver le comportement existant.
- Mettre à jour le titre de page et le footer dans `CartoModel.html` pour afficher la version `2.14.80`.

### Testing
- Exécuté `node --check assets/js/rms.ui.js` pour valider la syntaxe JavaScript, résultat: succès.
- Vérifié la présence de la nouvelle chaîne `v2.14.80` / `Version 2.14.80` dans `CartoModel.html` avec `rg`, résultat: succès.
- Vérification rapide du diff/statut des fichiers modifiés via `git show --stat`, résultat: fichiers modifiés correctement (2 fichiers).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e753ab45ac832e8df0f69cf4d2efc4)