### PR TITLE
Remove process/type filters from risks view and bump version to v2.14.81

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.80</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.81</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -640,18 +640,6 @@
                 <div class="content-area">
                     <div class="filters-bar">
                         <div class="filter-group">
-                            <label class="filter-label" for="risksProcessFilter">Process</label>
-                            <select class="filter-select" id="risksProcessFilter" data-risk-filter="process" onchange="applyFilters('process', this.value, this)">
-                                <option value="">All processes</option>
-                            </select>
-                        </div>
-                        <div class="filter-group">
-                            <label class="filter-label" for="risksTypeFilter">Risk Type</label>
-                            <select class="filter-select" id="risksTypeFilter" data-risk-filter="type" onchange="applyFilters('type', this.value, this)">
-                                <option value="">All types</option>
-                            </select>
-                        </div>
-                        <div class="filter-group">
                             <label class="filter-label" for="risksStatusFilter">Status</label>
                             <select class="filter-select" id="risksStatusFilter" data-risk-filter="status" onchange="applyFilters('status', this.value, this)">
                                 <option value="">All statuses</option>
@@ -888,7 +876,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.80</span>
+            <span class="app-version">Version 2.14.81</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -7698,39 +7698,17 @@ class RiskManagementSystem {
     getFilteredRisks(risks = this.risks) {
         const sourceRisks = Array.isArray(risks) ? risks : [];
         const {
-            process = '',
-            type = '',
             status = '',
             search = '',
             entity = []
         } = this.filters || {};
 
-        const processFilter = String(process || '').toLowerCase();
         const searchFilter = String(search || '').toLowerCase();
         const entityFilters = Array.isArray(entity)
             ? entity.map(value => String(value || '').toLowerCase()).filter(Boolean)
             : [];
 
         return sourceRisks.filter(risk => {
-            if (processFilter) {
-                const processValues = Array.isArray(risk?.processusAssocies) && risk.processusAssocies.length
-                    ? risk.processusAssocies
-                    : [risk?.processus];
-                const hasProcess = processValues.some(value => String(value || '').toLowerCase().includes(processFilter));
-                if (!hasProcess) {
-                    return false;
-                }
-            }
-
-            if (type) {
-                const typeValues = Array.isArray(risk?.typesCorruption) && risk.typesCorruption.length
-                    ? risk.typesCorruption
-                    : [risk?.typeCorruption];
-                if (!typeValues.some(value => value === type)) {
-                    return false;
-                }
-            }
-
             if (status) {
                 const riskStatus = this.normalizeStatusValue(
                     'risk',


### PR DESCRIPTION
### Motivation
- Simplify the Risk Register UI by removing the `process` and `type` filters from the risks list and corresponding filtering logic.
- Bump the app version to reflect the patch release `v2.14.81`.

### Description
- Removed the `Process` and `Risk Type` filter controls from `CartoModel.html` risk filters bar.
- Removed `process` and `type` from the destructured `this.filters` and deleted their filtering logic in `RiskManagementSystem.getFilteredRisks` in `assets/js/rms.core.js` so risks are no longer filtered by those keys.
- Updated the HTML title and footer version strings from `2.14.80` to `2.14.81` in `CartoModel.html`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e754fc9938832e85c4c52900915eca)