### PR TITLE
Ajout d’un risque par défaut dans les records et bump version 2.14.82

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.81</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.82</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -876,7 +876,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.81</span>
+            <span class="app-version">Version 2.14.82</span>
         </footer>
     </div>
 

--- a/assets/js/rms.data.records.js
+++ b/assets/js/rms.data.records.js
@@ -1,6 +1,28 @@
 (function (global) {
     const defaultDataSets = {
-        risks: [],
+        risks: [
+            {
+                id: 1,
+                processus: 'Achats',
+                processusAssocies: ['Achats'],
+                sousProcessus: 'Sélection des fournisseurs',
+                sousProcessusAssocies: ['Sélection des fournisseurs'],
+                typeCorruption: 'active',
+                typesCorruption: ['active'],
+                statut: 'a-valider',
+                description: "Risque de favoritisme lors de la sélection des fournisseurs critiques en raison d'une documentation incomplète des critères de choix.",
+                tiers: ['Suppliers'],
+                avantagesIndus: ["Attribution d'un marché à un fournisseur non conforme"],
+                avantagesAttendus: ["Accélération indue du processus d'achat"],
+                paysExposes: ['France', 'Mexico'],
+                probBrut: 3,
+                impactBrut: 4,
+                mitigationEffectiveness: 'ameliorable',
+                controls: [5, 6, 9],
+                actionPlans: [],
+                dateCreation: '2026-04-21'
+            }
+        ],
         controls: [
             { id: 1, reference: 'GEN.01', groupCode: '', name: 'Separation of medical and commercial roles (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'annuelle', mode: 'ongoing', effectiveness: 'to-be-improved', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },
             { id: 2, reference: 'GEN.02', groupCode: '', name: 'Segregation of duties (generic)', type: 'a-priori', origin: 'interne', owner: 'Compliance', frequency: 'annuelle', mode: 'ongoing', effectiveness: 'to-be-improved', status: 'actif', description: '', risks: [], dateCreation: '2026-04-16' },


### PR DESCRIPTION
### Motivation
- Fournir un exemple / jeu de données par défaut pour faciliter les démonstrations et les tests du registre des risques.
- Mettre à jour la version affichée dans l’application conformément à la règle de changer le numéro de version pour chaque tâche (Version mise à jour : `2.14.82`).

### Description
- Ajout d’un risque par défaut dans `assets/js/rms.data.records.js` (dataset `risks`) avec champs clefs : `processus`, `sousProcessus`, `typeCorruption`, `statut`, `description`, `paysExposes`, `probBrut`, `impactBrut`, `mitigationEffectiveness`, `controls` et `dateCreation`.
- Normalisation des chaînes contenant des apostrophes pour éviter les erreurs de syntaxe JavaScript (utilisation de guillemets doubles et échappement là où nécessaire).
- Valeur de `mitigationEffectiveness` réglée sur une valeur acceptée (`ameliorable`) compatible avec la logique existante de mitigation.
- Bump de la version dans `CartoModel.html` : changement du titre et du footer de `2.14.81` à `2.14.82`.

### Testing
- Vérification de syntaxe JavaScript : `node --check assets/js/rms.data.records.js` exécutée avec succès.
- Les fichiers modifiés se chargeront ensuite via la normalisation existante (`normalizeRisk`) lors du démarrage de l’application.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e759ac72d4832eb6260d7c7af6bd8c)