### PR TITLE
Recreate Register Register tab layout and bump footer version

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -150,7 +150,7 @@
                     📈 Risk Matrix
                 </button>
                 <button class="tab" onclick="switchTab('risks')">
-                    📋 Risk Register
+                    📋 Register Register
                 </button>
                 <button class="tab" onclick="switchTab('controls')">
                     🔒 Controls & Mitigation
@@ -622,11 +622,11 @@
             </div>
         </div>
 
-        <!-- Risks List Tab -->
+        <!-- Register Register Tab -->
         <div id="risks-tab" class="tab-content">
             <div class="main-content">
                 <div class="toolbar">
-                    <div class="toolbar-title">Risk Register</div>
+                    <div class="toolbar-title">Register Register</div>
                     <div class="toolbar-actions">
                         <button class="btn btn-secondary" onclick="exportRisks()">
                             📤 Export
@@ -638,43 +638,51 @@
                 </div>
 
                 <div class="content-area">
-                    <div class="filters-bar">
-                        <div class="filter-group">
-                            <label class="filter-label" for="risksStatusFilter">Status</label>
-                            <select class="filter-select" id="risksStatusFilter" data-risk-filter="status" onchange="applyFilters('status', this.value, this)">
-                                <option value="">All statuses</option>
-                            </select>
+                    <section class="register-register">
+                        <div class="register-register-headline">
+                            <h3 class="register-register-title">Risk inventory</h3>
+                            <p class="register-register-subtitle">Use filters to quickly find a risk and validate the display of all columns.</p>
                         </div>
-                        <div class="filter-group">
-                            <label class="filter-label" for="risksEntityFilterChips">Entities</label>
-                            <div id="risksEntityFilterChips" class="filter-chip-group" aria-label="Filter risks by entities"></div>
+
+                        <div class="filters-bar register-register-filters">
+                            <div class="filter-group">
+                                <label class="filter-label" for="risksStatusFilter">Status</label>
+                                <select class="filter-select" id="risksStatusFilter" data-risk-filter="status" onchange="applyFilters('status', this.value, this)">
+                                    <option value="">All statuses</option>
+                                </select>
+                            </div>
+                            <div class="filter-group filter-group-entities">
+                                <label class="filter-label" for="risksEntityFilterChips">Entities</label>
+                                <div id="risksEntityFilterChips" class="filter-chip-group" aria-label="Filter risks by entities"></div>
+                            </div>
+                            <div class="search-box filter-group">
+                                <label class="filter-label" for="risksSearchInput">Search</label>
+                                <input type="search" class="search-input" id="risksSearchInput" data-risk-filter="search" placeholder="🔍 Search a risk..." oninput="searchRisks(this.value, this)">
+                            </div>
                         </div>
-                        <div class="search-box filter-group">
-                            <label class="filter-label" for="risksSearchInput">Search</label>
-                            <input type="search" class="search-input" id="risksSearchInput" data-risk-filter="search" placeholder="🔍 Search a risk..." oninput="searchRisks(this.value, this)">
+
+                        <div class="table-container register-register-table-wrapper">
+                            <table id="risksTable">
+                                <thead>
+                                    <tr>
+                                        <th scope="col">ID</th>
+                                        <th scope="col">Description</th>
+                                        <th scope="col">Type</th>
+                                        <th scope="col">Tiers</th>
+                                        <th scope="col">Entities</th>
+                                        <th scope="col">Gross score</th>
+                                        <th scope="col">Aggravated score</th>
+                                        <th scope="col">Net score</th>
+                                        <th scope="col">Status</th>
+                                        <th scope="col">Action Plan</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="risksTableBody">
+                                    <!-- Populated by JavaScript -->
+                                </tbody>
+                            </table>
                         </div>
-                    </div>
-                    <div class="table-container">
-                        <table id="risksTable">
-                            <thead>
-                                <tr>
-                                    <th>ID</th>
-                                    <th>Description</th>
-                                    <th>Type</th>
-                                    <th>Tiers</th>
-                                    <th>Entities</th>
-                                    <th>Gross score</th>
-                                    <th>Aggravated score</th>
-                                    <th>Net score</th>
-                                    <th>Status</th>
-                                    <th>Action Plan</th>
-                                </tr>
-                            </thead>
-                            <tbody id="risksTableBody">
-                                <!-- Populated by JavaScript -->
-                            </tbody>
-                        </table>
-                    </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -876,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.82</span>
+            <span class="app-version">Version 2.14.83</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2033,6 +2033,42 @@ body.feedback-mode-paused .feedback-panel * {
     border: 1px solid var(--border-color);
 }
 
+.register-register {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    padding: 20px;
+}
+
+.register-register-headline {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.register-register-title {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--text-color);
+}
+
+.register-register-subtitle {
+    margin: 0;
+    color: var(--muted-text-color);
+    font-size: 0.9rem;
+}
+
+.register-register-filters {
+    padding: 16px;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background: var(--surface-alt-color);
+}
+
+.register-register-table-wrapper {
+    overflow-x: auto;
+}
+
 .table-header {
     background: linear-gradient(120deg, rgba(11, 61, 96, 0.08), transparent 70%);
     padding: 16px 24px;


### PR DESCRIPTION
### Motivation
- Rebuild the risks list view to fix potential display/layout bugs and make the register easier to read and validate across screen sizes.
- Preserve existing JS hooks/IDs so runtime behavior and existing scripts continue to work with the new layout.
- Update the app version shown in the footer as requested.

### Description
- Renamed the navigation label and rebuilt the `risks-tab` markup into a `Register Register` tab with a headline, subtitle and dedicated `section.register-register` wrapper while keeping existing IDs (`risksStatusFilter`, `risksEntityFilterChips`, `risksSearchInput`, `risksTableBody`).
- Reorganized filters into a grouped `filters-bar register-register-filters` and recreated the table with improved semantics (`scope="col"`) and a `register-register-table-wrapper` to enable horizontal scrolling for wide tables.
- Added new CSS rules under `.register-register*` to stabilize spacing, typography and overflow handling in `assets/css/main.css`.
- Bumped the footer version from `2.14.82` to `2.14.83` in `CartoModel.html`.

### Testing
- Ran `git diff --check` and no whitespace or diff-check issues were reported (success).
- No automated UI/browser rendering tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75cd54078832e86cad95469fefca5)