### PR TITLE
Fix risk creation modal opening and bump app version to 2.14.84

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.82</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.84</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.83</span>
+            <span class="app-version">Version 2.14.84</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1073,13 +1073,18 @@ window.renderAllRiskMultiSelectChips = renderAllRiskMultiSelectChips;
 function addNewRisk() {
     currentEditingRiskId = null;
     const form = document.getElementById('riskForm');
+    const refreshSubProcessOptions = () => {
+        if (window.rms && typeof rms.updateSousProcessusOptions === 'function') {
+            rms.updateSousProcessusOptions();
+        }
+    };
     if (form) {
         form.reset();
 
         const statutSelect = document.getElementById('statut');
         if (lastRiskData) {
             setSelectedValues('processus', lastRiskData.processusAssocies || (lastRiskData.processus ? [lastRiskData.processus] : []));
-            rms.updateSousProcessusOptions();
+            refreshSubProcessOptions();
             setSelectedValues('sousProcessus', lastRiskData.sousProcessusAssocies || (lastRiskData.sousProcessus ? [lastRiskData.sousProcessus] : []));
             setSelectedValues('typeCorruption', lastRiskData.typesCorruption || (lastRiskData.typeCorruption ? [lastRiskData.typeCorruption] : []));
             setSelectedValues('tiers', lastRiskData.tiers || []);
@@ -1112,7 +1117,7 @@ function addNewRisk() {
             selectedActionPlansForRisk = [...(lastRiskData.actionPlans || [])];
             setAggravatingFactorsSelection(lastRiskData.aggravatingFactors || null);
         } else {
-            rms.updateSousProcessusOptions();
+            refreshSubProcessOptions();
             selectedControlsForRisk = [];
             setRiskControlAssignments([]);
             setRiskBenefitChips('undue', []);


### PR DESCRIPTION
### Motivation
- The "+ New Risk" flow could fail when `rms.updateSousProcessusOptions` was not yet available, preventing the risk creation modal from opening.
- Make the initialization of the risk form defensive so the UI remains responsive even if `rms` or the method is not loaded yet.
- Also bump the visible application version as required by the release process (version mise à jour : `2.14.84`).

### Description
- Added a guarded helper `refreshSubProcessOptions()` in `assets/js/rms.ui.js` that calls `rms.updateSousProcessusOptions()` only when available and replaced direct calls with this helper in both the edit and create branches of `addNewRisk()`.
- Kept the existing modal open logic but made the subprocess update defensive to avoid a `ReferenceError` when `rms` isn't ready.
- Updated the page title and footer version string to `2.14.84` in `CartoModel.html`.

### Testing
- Ran `node --check assets/js/rms.ui.js` which succeeded.
- Ran `node --check assets/js/rms.core.js` which succeeded.
- Ran `node --check assets/js/main.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e75f2257d4832eaf63b5d4a51cbc7d)