### PR TITLE
Enable localStorage persistence for risks and bump version to 2.14.85

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.84</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.85</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.84</span>
+            <span class="app-version">Version 2.14.85</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -1,6 +1,6 @@
 // Enhanced Risk Management System - Core Logic
 
-const RMS_LOCAL_STORAGE_ENABLED = false;
+const RMS_LOCAL_STORAGE_ENABLED = true;
 
 let emptyChartPluginRegistered = false;
 


### PR DESCRIPTION
### Motivation
- Corriger la perte des risques créés en réactivant la persistance locale (`localStorage`) et mettre à jour le numéro de version affiché dans l’UI en footer/titre à `2.14.85`.

### Description
- Activation de la persistance locale en passant `RMS_LOCAL_STORAGE_ENABLED` à `true` dans `assets/js/rms.core.js` et mise à jour du titre de page et du footer de `2.14.84` → `2.14.85` dans `CartoModel.html`.

### Testing
- Exécution de `node --check assets/js/rms.core.js` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7609c05a4832ea8ff95dbbc6a672e)