### PR TITLE
Corrige risques runtime (applyPatch, import CSV, viewer) et passe la version à 2.14.89

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.87</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.89</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.88</span>
+            <span class="app-version">Version 2.14.89</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -10897,7 +10897,7 @@ class RiskManagementSystem {
             "'": '&#39;'
         }[match] || match));
 
-        const title = interview.title ? escapeHtml(interview.title) : 'Untitled interview report';
+        const title = interview.title ? String(interview.title) : 'Untitled interview report';
         const dateLabel = this.formatInterviewDate(interview.date);
         const updatedLabel = this.formatInterviewDateTime(interview.updatedAt || interview.createdAt);
 

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2331,15 +2331,15 @@ function applyPatch() {
       };
       const state = {
         get risks(){ return RMS.risks || window.risks || []; },
-        set risks(v){ if (RMS.risks) RMS.risks = v; else window.risks = v; },
+        set risks(v){ if ('risks' in RMS) RMS.risks = v; else window.risks = v; },
         get controls(){ return RMS.controls || window.controls || []; },
-        set controls(v){ if (RMS.controls) RMS.controls = v; else window.controls = v; },
+        set controls(v){ if ('controls' in RMS) RMS.controls = v; else window.controls = v; },
         get actionPlans(){ return RMS.actionPlans || window.actionPlans || []; },
-        set actionPlans(v){ if (RMS.actionPlans) RMS.actionPlans = v; else window.actionPlans = v; },
+        set actionPlans(v){ if ('actionPlans' in RMS) RMS.actionPlans = v; else window.actionPlans = v; },
         get history(){ return RMS.history || window.historyLog || []; },
-        set history(v){ if (RMS.history) RMS.history = v; else window.historyLog = v; },
+        set history(v){ if ('history' in RMS) RMS.history = v; else window.historyLog = v; },
         get interviews(){ return RMS.interviews || window.interviews || []; },
-        set interviews(v){ if (RMS.interviews) RMS.interviews = v; else window.interviews = v; },
+        set interviews(v){ if ('interviews' in RMS) RMS.interviews = v; else window.interviews = v; },
         save: (label="auto") => {
           try {
             if (RMS.saveData) { RMS.saveData(); }
@@ -2833,7 +2833,9 @@ function applyPatch() {
               }
               state.save("après import");
               state.renderAll();
-              toast && toast("Import successful");
+              if (typeof toast === 'function') {
+                toast("Import successful");
+              }
             } catch(err){
               console.error(err);
               alert("Erreur à l'import : " + err.message);


### PR DESCRIPTION
### Motivation
- Éviter des erreurs d'exécution observées lors d'utilisations réelles (ReferenceError / écritures globales non souhaitées / rendu incorrect du titre d'interview). 
- Renforcer la robustesse des importations CSV et de l'API d'application de correctifs sans modifier le modèle de données côté localStorage. 
- Respecter la consigne de versionner la release visible dans l'interface en incrémentant le numéro dans le footer et le titre de page.

### Description
- Renforcement des setters internes de `applyPatch` : les assignations utilisent maintenant l'opérateur `in` pour vérifier la présence de la propriété sur l'objet RMS avant d'écrire, évitant ainsi d'écraser des globals quand la propriété existe mais est falsy (`assets/js/rms.integrations.js`).
- Protection de l'appel de notification après import CSV : remplacement de `toast && toast(...)` par un contrôle sûr `typeof toast === 'function'` pour empêcher un appel invalide provoquant une erreur (`assets/js/rms.integrations.js`).
- Correction de l'affichage du titre dans le visualiseur d'interview en n'échappant plus deux fois le titre (utilisation de `String(interview.title)` avant d'assigner à `textContent`) pour éviter l'affichage littéral d'entités HTML (`assets/js/rms.core.js`).
- Mise à jour visible de la version de l'application dans le titre de la page et le footer vers `2.14.89` conformément à la règle de versioning demandée (`CartoModel.html`).

### Testing
- `node --check assets/js/rms.core.js` a été exécuté et s'est terminé sans erreur. 
- `node --check assets/js/rms.integrations.js` a été exécuté et s'est terminé sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e797cb9404832ead01b107549262ad)