### PR TITLE
chore: bump app version to 2.14.91

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.89</title>
+    <title>Corruption Risk Mapping - Sapin II v2.14.91</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.90</span>
+            <span class="app-version">Version 2.14.91</span>
         </footer>
     </div>
 

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.90',
+            version: '2.14.91',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- Mettre à jour le numéro de version affiché dans l'application et l'aligner avec les métadonnées d'export afin de refléter l'état actuel du build (mise à jour requise par le footer versioning policy). 

### Description
- Mise à jour du numéro de version affiché et des métadonnées : `CartoModel.html` titre changé à `v2.14.91` et footer `Version 2.14.91`, et `assets/js/rms.quick-assessment.js` `state.data.version` mis à `'2.14.91'`.

### Testing
- Vérifications automatiques effectuées : `git status --short` (ok) et `git commit -m "chore: bump app version to 2.14.91"` (commit successful), et inspection des fichiers modifiés pour confirmer les nouvelles chaînes de version (smoke check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b657e004832e849af1c96201a9a4)