### PR TITLE
Fix risk modal submission and New control flow; bump footer version to 2.14.93

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.92</span>
+            <span class="app-version">Version 2.14.93</span>
         </footer>
     </div>
 
@@ -1297,7 +1297,7 @@
                 <button class="modal-close" onclick="closeModal('riskModal')">&times;</button>
             </div>
             <div class="modal-body">
-                <form id="riskForm">
+                <form id="riskForm" onsubmit="saveRisk(); return false;" novalidate>
                     <div class="form-section">
                         <div class="form-section-title">General Information</div>
                         <div class="form-grid">
@@ -1536,7 +1536,7 @@
             </div>
             <div class="modal-footer">
                 <button class="btn btn-secondary" onclick="closeModal('riskModal')">Cancel</button>
-                <button class="btn btn-success" onclick="saveRisk()">Save</button>
+                <button class="btn btn-success" type="submit" form="riskForm">Save</button>
             </div>
         </div>
     </div>

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1401,8 +1401,10 @@ function createControlFromRisk() {
         transverse: !benefitLabel
     };
     closeControlSelector();
-    if (typeof addNewControl === 'function') {
-        addNewControl();
+    if (typeof window.addNewControl === 'function') {
+        window.addNewControl();
+    } else if (typeof showNotification === 'function') {
+        showNotification('error', 'Unable to open the control creation form.');
     }
 }
 window.createControlFromRisk = createControlFromRisk;


### PR DESCRIPTION
### Motivation
- Users reported that the **Save** button in the risk modal did not reliably create a new risk because it did not submit the risk form through the native form pipeline.  
- The “New control” action from the risk control selector could fail silently when the control creation function was not reachable in the expected scope.  
- The footer version needed to be incremented per release practice.

### Description
- Wire the risk modal to the native form submit by adding `onsubmit="saveRisk(); return false;"` to the `riskForm` and turning the modal Save button into a form submit (`type="submit" form="riskForm"`).  
- Harden `createControlFromRisk()` to call `window.addNewControl()` explicitly and show a user-facing error via `showNotification` if the control creation UI is unavailable.  
- Bumped the footer version string from `Version 2.14.92` to `Version 2.14.93` as requested.

### Testing
- Syntax check: ran `node --check assets/js/rms.ui.js` which completed successfully.  
- Verified the HTML/JS wiring changes via diff review to ensure the form submission and control-opening code paths are correctly updated.  
- Confirmed the footer version now reads `2.14.93`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88414ab98832ebcd9a97e772cab26)