### PR TITLE
Restore matrix Edit mode drag-and-drop and bump footer version to 2.14.94

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.93</span>
+            <span class="app-version">Version 2.14.94</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -7544,7 +7544,9 @@ class RiskManagementSystem {
                     };
                     cell.ondrop = (event) => {
                         event.preventDefault();
-                        const riskId = event.dataTransfer?.getData('text/risk-id');
+                        const riskId = event.dataTransfer?.getData('text/risk-id')
+                            || event.dataTransfer?.getData('text/plain')
+                            || window.matrixDraggedRiskId;
                         if (!riskId) return;
                         const probability = parseInt(cell.dataset.probability, 10);
                         const impact = parseInt(cell.dataset.impact, 10);
@@ -7689,7 +7691,13 @@ class RiskManagementSystem {
                 if (viewKey === 'brut' && window.matrixEditMode) {
                     point.draggable = true;
                     point.addEventListener('dragstart', (event) => {
-                        event.dataTransfer?.setData('text/risk-id', String(risk.id));
+                        const riskId = String(risk.id);
+                        window.matrixDraggedRiskId = riskId;
+                        event.dataTransfer?.setData('text/risk-id', riskId);
+                        event.dataTransfer?.setData('text/plain', riskId);
+                    });
+                    point.addEventListener('dragend', () => {
+                        window.matrixDraggedRiskId = null;
                     });
                 }
                 grid.appendChild(point);

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -47,6 +47,7 @@ function switchTab(tabNameOrEvent, maybeTabName) {
 window.switchTab = switchTab;
 
 window.matrixEditMode = false;
+window.matrixDraggedRiskId = null;
 
 function toggleMatrixEditMode(forceState = null) {
     const nextState = typeof forceState === 'boolean' ? forceState : !window.matrixEditMode;


### PR DESCRIPTION
### Motivation
- Le mode Edit de la matrice ne repositionnait pas les risques de façon fiable dans certains navigateurs quand `dataTransfer` ne contenait pas le payload attendu, rendant le drag & drop inutilisable; il faut donc un fallback robuste pour la lecture de l'ID du risque.
- Il faut éviter les IDs résiduels après un drag et respecter la règle de versioning dans le footer en incrémentant la version affichée.

### Description
- Le gestionnaire `ondrop` lit maintenant l'ID du risque depuis `text/risk-id`, puis `text/plain`, puis depuis un fallback global `window.matrixDraggedRiskId` si nécessaire, afin d'assurer la compatibilité inter-navigateurs (`assets/js/rms.core.js`).
- Le `dragstart` écrit à la fois `text/risk-id` et `text/plain` et renseigne `window.matrixDraggedRiskId`, et `dragend` nettoie cette variable pour éviter les IDs résiduels (`assets/js/rms.core.js`).
- Ajout de la propriété globale `window.matrixDraggedRiskId = null` côté UI pour exposer le fallback (`assets/js/rms.ui.js`).
- Mise à jour de la version affichée dans le footer de l'application à `Version 2.14.94` (`CartoModel.html`).

### Testing
- Parsing rapide du JavaScript avec `node -e "const fs=require('fs'); new Function(fs.readFileSync('assets/js/rms.core.js','utf8')); new Function(fs.readFileSync('assets/js/rms.ui.js','utf8')); console.log('JS parse OK');"` a renvoyé `JS parse OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8862a7970832ebe02c1a829f79eda)