### PR TITLE
Normalise les comparaisons d'IDs dans saveRisk et affiche les erreurs de mise à jour de relations

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.94</span>
+            <span class="app-version">Version 2.14.95</span>
         </footer>
     </div>
 

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -1182,6 +1182,7 @@ window.getSelectedActionPlansForRisk = () => selectedActionPlansForRisk;
 function saveRisk() {
     if (!rms) return;
     let riskSaved = false;
+    const relationUpdateErrors = [];
 
     const aggravatingSelection = typeof getFormAggravatingSelection === 'function'
         ? getFormAggravatingSelection()
@@ -1266,7 +1267,7 @@ function saveRisk() {
             // Update control links
             rms.controls.forEach(control => {
                 control.risks = control.risks || [];
-                if (selectedControlsForRisk.includes(control.id)) {
+                if (selectedControlsForRisk.some(id => idsEqual(id, control.id))) {
                     if (!control.risks.some(id => idsEqual(id, targetId))) {
                         control.risks.push(rms.risks[riskIndex].id);
                     }
@@ -1277,12 +1278,24 @@ function saveRisk() {
 
             rms.actionPlans.forEach(plan => {
                 plan.risks = plan.risks || [];
-                if (selectedActionPlansForRisk.includes(plan.id)) {
+                if (selectedActionPlansForRisk.some(id => idsEqual(id, plan.id))) {
                     if (!plan.risks.some(id => idsEqual(id, targetId))) {
                         plan.risks.push(rms.risks[riskIndex].id);
                     }
                 } else {
                     plan.risks = plan.risks.filter(id => !idsEqual(id, targetId));
+                }
+            });
+
+            selectedControlsForRisk.forEach(controlId => {
+                if (!rms.controls.some(control => idsEqual(control.id, controlId))) {
+                    relationUpdateErrors.push(`Contrôle introuvable (id=${controlId})`);
+                }
+            });
+
+            selectedActionPlansForRisk.forEach(planId => {
+                if (!rms.actionPlans.some(plan => idsEqual(plan.id, planId))) {
+                    relationUpdateErrors.push(`Plan d'action introuvable (id=${planId})`);
                 }
             });
 
@@ -1300,22 +1313,26 @@ function saveRisk() {
         const newRisk = rms.addRisk(formData);
 
         selectedControlsForRisk.forEach(controlId => {
-            const ctrl = rms.controls.find(c => c.id === controlId);
+            const ctrl = rms.controls.find(c => idsEqual(c.id, controlId));
             if (ctrl) {
                 ctrl.risks = ctrl.risks || [];
-                if (!ctrl.risks.includes(newRisk.id)) {
+                if (!ctrl.risks.some(id => idsEqual(id, newRisk.id))) {
                     ctrl.risks.push(newRisk.id);
                 }
+            } else {
+                relationUpdateErrors.push(`Contrôle introuvable (id=${controlId})`);
             }
         });
 
         selectedActionPlansForRisk.forEach(planId => {
-            const plan = rms.actionPlans.find(p => p.id === planId);
+            const plan = rms.actionPlans.find(p => idsEqual(p.id, planId));
             if (plan) {
                 plan.risks = plan.risks || [];
-                if (!plan.risks.includes(newRisk.id)) {
+                if (!plan.risks.some(id => idsEqual(id, newRisk.id))) {
                     plan.risks.push(newRisk.id);
                 }
+            } else {
+                relationUpdateErrors.push(`Plan d'action introuvable (id=${planId})`);
             }
         });
 
@@ -1331,6 +1348,10 @@ function saveRisk() {
 
     if (riskSaved) {
         closeModal('riskModal');
+    }
+
+    if (relationUpdateErrors.length) {
+        showNotification('warning', `Certaines relations n'ont pas pu être mises à jour : ${relationUpdateErrors.join(', ')}`);
     }
 
     if (rms) {


### PR DESCRIPTION
### Motivation
- Corriger des comparaisons fragiles d'IDs (`includes` / `===`) dans la sauvegarde des risques là où l'ID du formulaire peut être une `string` alors que l'ID métier est numérique. 
- S'assurer que les liens contrôle ↔ risque et plan ↔ risque sont mis à jour de façon robuste en utilisant la fonction `idsEqual`. 
- Éviter le silence côté UX quand une relation ne peut pas être mise à jour en ajoutant une notification explicite. 
- Mettre à jour la version affichée dans le footer pour refléter la modification (`2.14.94` → `2.14.95`).

### Description
- Remplacé les usages de `selectedControlsForRisk.includes(control.id)` et `selectedActionPlansForRisk.includes(plan.id)` par des vérifications `some(id => idsEqual(id, control.id))` / `some(id => idsEqual(id, plan.id))` dans `saveRisk()` (édition). (`assets/js/rms.ui.js`)
- Normalisé les recherches `find(... === ...)` et les tests d'existence dans le bloc ``new risk`` en utilisant `idsEqual` lors de l'ajout des relations pour le nouveau risque. (`assets/js/rms.ui.js`)
- Ajouté un tableau `relationUpdateErrors` et des `relationUpdateErrors.push(...)` lorsque des contrôles ou plans d'action référencés sont introuvables, puis affichage d'une notification `showNotification('warning', ...)` si des erreurs ont eu lieu. (`assets/js/rms.ui.js`)
- Remplacé `includes` sur les tableaux de `risks` par des `some(id => idsEqual(id, ...))` pour vérifier l'existence d'un lien de façon normalisée. (`assets/js/rms.ui.js`)
- Incrémenté la version dans `CartoModel.html` à `Version 2.14.95`.

### Testing
- Exécuté `node --check assets/js/rms.ui.js`, qui a réussi sans erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88c169ea0832e86d0dbe4add9982d)