### PR TITLE
Harden config section rendering with guarded swap and retry UI

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.95</span>
+            <span class="app-version">Version 2.14.96</span>
         </footer>
     </div>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5063,6 +5063,25 @@ tbody tr:hover {
     gap: 16px;
 }
 
+
+.config-render-error {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px 16px;
+    background: rgba(231, 76, 60, 0.1);
+    border: 1px solid rgba(231, 76, 60, 0.35);
+    border-radius: 10px;
+    color: #8b1e12;
+    padding: 12px 14px;
+    margin-bottom: 14px;
+}
+
+.config-render-error p {
+    margin: 0;
+    flex: 1 1 100%;
+}
+
 .config-section-description {
     background: var(--surface-alt-color);
     border: 1px solid var(--border-color);

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -3108,7 +3108,10 @@ class RiskManagementSystem {
 
     renderConfiguration() {
         const container = document.getElementById('configurationContainer');
-        if (!container) return;
+        if (!container) {
+            console.error('[renderConfiguration] Missing #configurationContainer element.');
+            return;
+        }
 
         const availableSections = [
             { id: 'processManager', label: 'Processes & referents' },
@@ -3118,6 +3121,37 @@ class RiskManagementSystem {
 
         if (!this.currentConfigSection || !availableSections.some(section => section.id === this.currentConfigSection)) {
             this.currentConfigSection = 'processManager';
+        }
+
+        const activeSection = availableSections.find(section => section.id === this.currentConfigSection) || availableSections[0];
+
+        const showSectionError = (sectionLabel, error) => {
+            console.error(`[renderConfiguration] Error while rendering section "${sectionLabel}".`, error);
+
+            const previousError = container.querySelector('[data-config-render-error="true"]');
+            if (previousError) {
+                previousError.remove();
+            }
+
+            const errorBlock = document.createElement('div');
+            errorBlock.className = 'config-render-error';
+            errorBlock.setAttribute('data-config-render-error', 'true');
+            errorBlock.setAttribute('role', 'alert');
+            errorBlock.innerHTML = `<strong>⚠️ Impossible d'afficher la section “${sectionLabel}”.</strong><p>Une erreur est survenue pendant le rendu.</p>`;
+
+            const retryButton = document.createElement('button');
+            retryButton.type = 'button';
+            retryButton.className = 'btn-secondary';
+            retryButton.textContent = 'Recharger la section';
+            retryButton.addEventListener('click', () => this.renderConfiguration());
+            errorBlock.appendChild(retryButton);
+
+            container.prepend(errorBlock);
+        };
+
+        if (!this.config || !Array.isArray(this.config.processes)) {
+            showSectionError(activeSection.label, new Error('Configuration prerequisites are missing (this.config / this.config.processes).'));
+            return;
         }
 
         const exportButton = document.getElementById('configExportButton');
@@ -3136,22 +3170,20 @@ class RiskManagementSystem {
             }
         }
 
-        this.closeActiveInsertionForm();
-        this.dragState = null;
-        container.innerHTML = '';
+        const nextView = document.createElement('div');
 
         if (this.currentConfigSection !== 'history') {
             const heading = document.createElement('h2');
             heading.className = 'admin-section-title';
             heading.textContent = 'Paramètres de configuration';
-            container.appendChild(heading);
+            nextView.appendChild(heading);
 
             const helper = document.createElement('div');
             helper.className = 'config-helper';
             const helperText = document.createElement('p');
             helperText.textContent = "💡 Use the save button in the header to store risks, controls, and action plans. From this section, export your processes or other settings to share or archive them.";
             helper.appendChild(helperText);
-            container.appendChild(helper);
+            nextView.appendChild(helper);
         }
 
         const tabs = document.createElement('div');
@@ -3167,22 +3199,32 @@ class RiskManagementSystem {
             });
             tabs.appendChild(button);
         });
-        container.appendChild(tabs);
+        nextView.appendChild(tabs);
 
         const content = document.createElement('div');
         content.className = 'config-section-panel';
-        container.appendChild(content);
+        nextView.appendChild(content);
 
-        if (this.currentConfigSection === 'processManager') {
-            this.processManagerContainer = content;
-            this.renderProcessManager(content);
-        } else if (this.currentConfigSection === 'general') {
-            this.processManagerContainer = null;
-            this.renderGeneralConfiguration(content);
-        } else {
-            this.processManagerContainer = null;
-            this.renderHistoryConfiguration(content);
+        try {
+            this.closeActiveInsertionForm();
+            this.dragState = null;
+
+            if (this.currentConfigSection === 'processManager') {
+                this.processManagerContainer = content;
+                this.renderProcessManager(content);
+            } else if (this.currentConfigSection === 'general') {
+                this.processManagerContainer = null;
+                this.renderGeneralConfiguration(content);
+            } else {
+                this.processManagerContainer = null;
+                this.renderHistoryConfiguration(content);
+            }
+        } catch (error) {
+            showSectionError(activeSection.label, error);
+            return;
         }
+
+        container.replaceChildren(...nextView.childNodes);
     }
 
     renderGeneralConfiguration(container) {


### PR DESCRIPTION
### Motivation
- Prevent the configuration panel from going blank when a section render fails by making rendering more defensive and recoverable.
- Surface contextual errors and give users a retry action when `renderProcessManager`, `renderGeneralConfiguration` or `renderHistoryConfiguration` throw.
- Fail early when prerequisites are missing to avoid running into unclear runtime errors.

### Description
- Added early checks for `#configurationContainer`, `this.config` and `this.config.processes` and report a clear error when missing.
- Wrapped the per-section rendering in a `try/catch` and introduced `showSectionError()` which logs the error via `console.error` and injects a visible `.config-render-error` block with a `Recharger la section` retry button into the `#configurationContainer`.
- Switched to a staged render using a `nextView` element and atomically swap the view with `container.replaceChildren(...nextView.childNodes)` so the previous content remains visible until the new render succeeds.
- Added CSS for `.config-render-error` and bumped the footer app version to `2.14.96`.

### Testing
- Validated JavaScript syntax by running `node -e "new Function(require('fs').readFileSync('assets/js/rms.core.js','utf8'))"`, which completed successfully.
- Confirmed the updated files parse without syntax errors (`assets/js/rms.core.js`, `assets/css/main.css`, `CartoModel.html`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88e6df3d4832e88525dee69ae538c)