### PR TITLE
Harden control boot and move control entrypoint wiring out of applyPatch

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -693,7 +693,7 @@
                 <div class="toolbar">
                     <div class="toolbar-title">Controls and Mitigation Measures</div>
                     <div class="toolbar-actions">
-                        <button class="btn btn-primary" onclick="addNewControl()">
+                        <button id="newControlButton" class="btn btn-primary" onclick="if (typeof window.addNewControl === 'function') { window.addNewControl(); } else { console.error('[UI] addNewControl indisponible depuis le bouton New Control.'); alert('Action impossible : module New Control non initialisé.'); }">
                             + New Control
                         </button>
                     </div>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.96</span>
+            <span class="app-version">Version 2.14.97</span>
         </footer>
     </div>
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,6 +8,48 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof registerBeforeUnloadWarning === 'function') {
         registerBeforeUnloadWarning();
     }
-    applyPatch();
+    try {
+        applyPatch();
+    } catch (error) {
+        console.error('[Boot] applyPatch() failed during startup.', error);
+    }
+    initializeNewControlUiGuard();
+    verifyControlBootIntegrity();
     rms.renderAll();
 });
+
+function notifyBootIssue(message) {
+    const normalizedMessage = (typeof message === 'string' && message.trim())
+        ? message.trim()
+        : 'Une erreur de démarrage est survenue.';
+    if (typeof window.showNotification === 'function') {
+        window.showNotification(normalizedMessage, 'error');
+        return;
+    }
+    alert(normalizedMessage);
+}
+
+function initializeNewControlUiGuard() {
+    const button = document.getElementById('newControlButton');
+    if (!button || button.dataset.controlListenerInitialized === 'true') {
+        return;
+    }
+
+    button.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (typeof window.addNewControl === 'function') {
+            window.addNewControl();
+            return;
+        }
+        notifyBootIssue('Action impossible : addNewControl est indisponible.');
+    });
+    button.dataset.controlListenerInitialized = 'true';
+}
+
+function verifyControlBootIntegrity() {
+    if (typeof window.addNewControl !== 'function') {
+        const message = '[Boot] addNewControl is unavailable after initialization.';
+        console.error(message);
+        notifyBootIssue('Initialisation incomplète : fonctionnalité New Control indisponible.');
+    }
+}

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2315,6 +2315,49 @@ function loadRmsDataFromFile() {
     input.click();
 }
 window.loadRmsDataFromFile = loadRmsDataFromFile;
+function notifyControlBootFailure(message) {
+    const normalizedMessage = (typeof message === 'string' && message.trim())
+        ? message.trim()
+        : 'Le module de gestion des contrôles n’est pas disponible.';
+    console.error(`[ControlBoot] ${normalizedMessage}`);
+    if (typeof window.showNotification === 'function') {
+        window.showNotification(normalizedMessage, 'error');
+        return;
+    }
+    if (typeof window.toast === 'function') {
+        window.toast(normalizedMessage);
+        return;
+    }
+    alert(normalizedMessage);
+}
+
+function initializeControlEntryPoints(dependencies = {}) {
+    window.__controlEntryPointsContext = dependencies;
+    if (window.__controlEntryPointsInitialized) {
+        return;
+    }
+
+    const invoke = (handlerName) => {
+        const context = window.__controlEntryPointsContext || {};
+        const handler = context[handlerName];
+        if (typeof handler === 'function') {
+            return handler();
+        }
+        notifyControlBootFailure(`Impossible d’exécuter "${handlerName}" : initialisation incomplète.`);
+        return null;
+    };
+
+    window.addNewControl = function addNewControlEntryPoint() {
+        return invoke('openNewControlModal');
+    };
+
+    window.saveControl = function saveControlEntryPoint() {
+        return invoke('persistControlForm');
+    };
+
+    window.__controlEntryPointsInitialized = true;
+}
+
 function applyPatch() {
     (function(){
       const RMS = window.rms || window.RMS || window.RiskSystem || {};
@@ -2999,7 +3042,7 @@ function applyPatch() {
         }
       }
 
-      window.addNewControl = function() {
+      function openNewControlModal() {
         ensureAllControlReferences();
         currentEditingControlId = null;
         const form = document.getElementById('controlForm');
@@ -3036,7 +3079,7 @@ function applyPatch() {
             modal.classList.add('show');
           }
         }
-      };
+      }
 
       window.editControl = function(controlId) {
         ensureAllControlReferences();
@@ -3217,7 +3260,7 @@ function applyPatch() {
         }
       };
 
-      window.saveControl = function() {
+      function persistControlForm() {
         ensureAllControlReferences();
         const form = document.getElementById('controlForm');
         if (!form) return;
@@ -3339,7 +3382,12 @@ function applyPatch() {
         if (RMS && typeof RMS.clearUnsavedChanges === 'function') {
           RMS.clearUnsavedChanges('controlForm');
         }
-      };
+      }
+
+      initializeControlEntryPoints({
+        openNewControlModal,
+        persistControlForm
+      });
 
       function toast(msg){
         const t = document.createElement('div');


### PR DESCRIPTION
### Motivation
- Améliorer la résilience du démarrage front-end en retirant le branchement direct de `addNewControl`/`saveControl` du bloc monolithique `applyPatch()` pour éviter des états partiels si l’initialisation échoue.
- Fournir des messages d’erreur clairs et une protection côté UI pour l’action « New Control » afin d’éviter des erreurs JS silencieuses à l’usage.
- Mettre à jour la version affichée dans le footer pour refléter la modification (version passée à `2.14.97`).

### Description
- Extraction d’un initialiseur idempotent `initializeControlEntryPoints(deps)` dans `assets/js/rms.integrations.js` qui expose des entrypoints délégués `window.addNewControl` et `window.saveControl` et notifie en cas d’échec d’initialisation via `notifyControlBootFailure`.
- Renommage des fonctions internes de contrôle en handlers locaux `openNewControlModal` et `persistControlForm` et branchement de ces handlers via l’initialiseur au lieu de définir directement les globals dans `applyPatch()`.
- Protection de l’appel `applyPatch()` dans `assets/js/main.js` par un `try/catch` avec log d’erreur clair et ajout d’un contrôle d’intégrité de démarrage `verifyControlBootIntegrity()` qui alerte immédiatement si `addNewControl` n’est pas disponible.
- Ajout d’un garde-fou UI : ajout de `id="newControlButton"` au bouton New Control dans `CartoModel.html`, un listener JS idempotent `initializeNewControlUiGuard()` qui appelle `window.addNewControl()` quand disponible, et fallback inline côté HTML qui affiche un message d’erreur si l’action est déclenchée alors que le module n’est pas initialisé.
- Bump de la version affichée dans le footer à `Version 2.14.97`.

### Testing
- Exécution statique : `node --check assets/js/main.js` — Succès.
- Exécution statique : `node --check assets/js/rms.integrations.js` — Succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e890ef02c8832eb17712a13aac1fe8)