### PR TITLE
Renforcer bootstrapping New Control et incrémenter version footer à 2.14.98

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.97</span>
+            <span class="app-version">Version 2.14.98</span>
         </footer>
     </div>
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (typeof registerBeforeUnloadWarning === 'function') {
         registerBeforeUnloadWarning();
     }
+    if (typeof initializeControlEntryPoints === 'function') {
+        initializeControlEntryPoints();
+    }
     try {
         applyPatch();
     } catch (error) {

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2332,7 +2332,8 @@ function notifyControlBootFailure(message) {
 }
 
 function initializeControlEntryPoints(dependencies = {}) {
-    window.__controlEntryPointsContext = dependencies;
+    const previousContext = window.__controlEntryPointsContext || {};
+    window.__controlEntryPointsContext = { ...previousContext, ...dependencies };
     if (window.__controlEntryPointsInitialized) {
         return;
     }
@@ -2356,6 +2357,10 @@ function initializeControlEntryPoints(dependencies = {}) {
     };
 
     window.__controlEntryPointsInitialized = true;
+}
+
+function registerControlEntryPointHandlers(dependencies = {}) {
+    initializeControlEntryPoints(dependencies);
 }
 
 function applyPatch() {
@@ -3384,7 +3389,7 @@ function applyPatch() {
         }
       }
 
-      initializeControlEntryPoints({
+      registerControlEntryPointHandlers({
         openNewControlModal,
         persistControlForm
       });


### PR DESCRIPTION
### Motivation
- Éviter que l'échec de la phase de patch (monolithique) rende indisponibles les points d'entrée UI `addNewControl`/`saveControl` au démarrage.
- Rendre l'initialisation des handlers idempotente et modulaire pour pouvoir brancher les handlers métier sans redéfinir de globals fragiles.
- Fournir des garde‑fous UI et une vérification d'intégrité au boot pour signaler immédiatement un démarrage incomplet.
- Conformément à la règle de versionnement, incrémenter le numéro de version dans le footer pour cette tâche.  (nouvelle version : `2.14.98`).

### Description
- Extraction de l'initialisation des entry points dans `initializeControlEntryPoints(dependencies = {})` et changement pour merger le contexte existant au lieu de l'écraser, ce qui rend l'initialisation idempotente (`assets/js/rms.integrations.js`).
- Ajout de `registerControlEntryPointHandlers(dependencies = {})` comme helper pour brancher les handlers métier depuis le flux d'intégration, et remplacement de l'appel direct dans le bloc patch par `registerControlEntryPointHandlers({ openNewControlModal, persistControlForm })` (`assets/js/rms.integrations.js`).
- Démarrage durci dans `assets/js/main.js` : appel à `initializeControlEntryPoints()` avant `applyPatch()`, conservation du `try/catch` autour de `applyPatch()` et maintien des garde‑fous UI (`initializeNewControlUiGuard`) et de la vérification d'intégrité (`verifyControlBootIntegrity`).
- Mise à jour du footer de l'application à la version `2.14.98` dans `CartoModel.html`.

### Testing
- Exécution de `node --check assets/js/main.js` : succès.
- Exécution de `node --check assets/js/rms.integrations.js` : succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e892fb2ab0832ea3acac257fdea18b)