### PR TITLE
Centralize matrix edit mode in RMS and add DnD drop diagnostics

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.98</span>
+            <span class="app-version">Version 2.14.99</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -132,6 +132,7 @@ class RiskManagementSystem {
         }
         this.needsConfigStructureRerender = configStructureUpdated;
         this.currentView = 'brut';
+        this.matrixEditMode = false;
         this.processScoreMode = 'net';
         this.currentTab = 'dashboard';
         this.currentConfigSection = 'processManager';
@@ -7578,7 +7579,7 @@ class RiskManagementSystem {
                 grid.querySelectorAll('.matrix-cell').forEach(cell => {
                     cell.ondragover = null;
                     cell.ondrop = null;
-                    if (!window.matrixEditMode) {
+                    if (!this.matrixEditMode) {
                         return;
                     }
                     cell.ondragover = (event) => {
@@ -7589,9 +7590,23 @@ class RiskManagementSystem {
                         const riskId = event.dataTransfer?.getData('text/risk-id')
                             || event.dataTransfer?.getData('text/plain')
                             || window.matrixDraggedRiskId;
-                        if (!riskId) return;
+                        if (!riskId) {
+                            console.debug('[MatrixDnD] Drop ignored: missing risk id.', { cell: { ...cell.dataset } });
+                            return;
+                        }
+
+                        if (!this.matrixEditMode) {
+                            console.debug('[MatrixDnD] Drop ignored: matrix edit mode is disabled.', { riskId });
+                            return;
+                        }
+
                         const probability = parseInt(cell.dataset.probability, 10);
                         const impact = parseInt(cell.dataset.impact, 10);
+                        if (!Number.isFinite(probability) || !Number.isFinite(impact)) {
+                            console.debug('[MatrixDnD] Drop ignored: invalid matrix cell.', { riskId, probability: cell.dataset.probability, impact: cell.dataset.impact });
+                            return;
+                        }
+
                         if (typeof window.applyMatrixRiskMove === 'function') {
                             window.applyMatrixRiskMove(riskId, probability, impact);
                         }
@@ -7730,8 +7745,8 @@ class RiskManagementSystem {
                 point.textContent = rankMapByView[viewKey]?.[String(risk.id)] || '';
                 point.setAttribute('aria-label', `${config.label} : ${risk.description}`);
                 point.onclick = () => this.selectRisk(risk.id);
-                if (viewKey === 'brut' && window.matrixEditMode) {
-                    point.draggable = true;
+                point.draggable = viewKey === 'brut' && this.matrixEditMode;
+                if (point.draggable) {
                     point.addEventListener('dragstart', (event) => {
                         const riskId = String(risk.id);
                         window.matrixDraggedRiskId = riskId;

--- a/assets/js/rms.ui.js
+++ b/assets/js/rms.ui.js
@@ -46,12 +46,16 @@ function switchTab(tabNameOrEvent, maybeTabName) {
 }
 window.switchTab = switchTab;
 
-window.matrixEditMode = false;
 window.matrixDraggedRiskId = null;
 
 function toggleMatrixEditMode(forceState = null) {
-    const nextState = typeof forceState === 'boolean' ? forceState : !window.matrixEditMode;
-    window.matrixEditMode = nextState;
+    const rmsInstance = window.rms || null;
+    const currentState = Boolean(rmsInstance && rmsInstance.matrixEditMode);
+    const nextState = typeof forceState === 'boolean' ? forceState : !currentState;
+
+    if (rmsInstance) {
+        rmsInstance.matrixEditMode = nextState;
+    }
     const button = document.getElementById('matrixEditToggleBtn');
     if (button) {
         button.classList.toggle('btn-primary', nextState);
@@ -59,8 +63,8 @@ function toggleMatrixEditMode(forceState = null) {
         button.textContent = nextState ? 'Edit mode active' : 'Edit mode';
     }
     document.body.classList.toggle('matrix-edit-mode', nextState);
-    if (window.rms) {
-        rms.renderRiskPoints();
+    if (rmsInstance) {
+        rmsInstance.renderRiskPoints();
     }
     if (typeof showNotification === 'function') {
         showNotification('info', nextState
@@ -1379,12 +1383,31 @@ function saveRisk() {
 window.saveRisk = saveRisk;
 
 function applyMatrixRiskMove(riskId, probability, impact) {
-    if (!rms || !window.matrixEditMode) return;
-    const risk = Array.isArray(rms.risks) ? rms.risks.find(item => idsEqual(item.id, riskId)) : null;
-    if (!risk) return;
+    if (!rms || !rms.matrixEditMode) {
+        console.debug('[MatrixDnD] Drop ignored: matrix edit mode is disabled.', { riskId, probability, impact });
+        return;
+    }
 
-    const nextProb = Math.min(4, Math.max(1, parseInt(probability, 10) || 1));
-    const nextImpact = Math.min(4, Math.max(1, parseInt(impact, 10) || 1));
+    if (riskId == null || riskId === '') {
+        console.debug('[MatrixDnD] Drop ignored: missing risk id.', { riskId, probability, impact });
+        return;
+    }
+
+    const parsedProb = parseInt(probability, 10);
+    const parsedImpact = parseInt(impact, 10);
+    if (!Number.isFinite(parsedProb) || !Number.isFinite(parsedImpact)) {
+        console.debug('[MatrixDnD] Drop ignored: invalid matrix cell coordinates.', { riskId, probability, impact });
+        return;
+    }
+
+    const risk = Array.isArray(rms.risks) ? rms.risks.find(item => idsEqual(item.id, riskId)) : null;
+    if (!risk) {
+        console.debug('[MatrixDnD] Drop ignored: risk not found.', { riskId, probability, impact });
+        return;
+    }
+
+    const nextProb = Math.min(4, Math.max(1, parsedProb || 1));
+    const nextImpact = Math.min(4, Math.max(1, parsedImpact || 1));
     risk.probBrut = nextProb;
     risk.impactBrut = nextImpact;
 


### PR DESCRIPTION
### Motivation
- Centraliser la propriété du mode édition de la matrice dans l'instance RMS afin d'éviter des états globaux divergents et des régressions lors du rendu/déclenchement DnD.
- S'assurer que l'activation/désactivation du mode d'édition met à jour l'état RMS puis force un rerender cohérent des points de matrice.
- Rendre le comportement de drop plus robuste en ajoutant des vérifications runtime quand un drop est ignoré pour faciliter le diagnostic.
- Incrémenter la version affichée en footer pour tracer la modification (version mise à jour).

### Description
- Déplacement de l'état : ajout de `this.matrixEditMode = false` dans le constructeur de `RiskManagementSystem` et suppression de la dépendance à `window.matrixEditMode` pour la lecture/écriture principale (`assets/js/rms.core.js`).
- `toggleMatrixEditMode` (`assets/js/rms.ui.js`) met maintenant à jour `rmsInstance.matrixEditMode` puis appelle `rmsInstance.renderRiskPoints()` pour rerendre la matrice à partir de l'état RMS.
- `renderRiskPoints` lit `this.matrixEditMode` et applique systématiquement `ondragover`/`ondrop` sur les cellules et `draggable` sur les points en fonction de cet état, en réduisant la logique dispersée sur le `window` global (`assets/js/rms.core.js`).
- Renforcement des contrôles runtime : ajout de `console.debug` quand un drop est ignoré pour cause d'ID manquant, cellule invalide, mode édition désactivé ou risque introuvable, et validation des coordonnées de cellule avant de propager le move (`assets/js/rms.core.js` et `assets/js/rms.ui.js`).
- Mise à jour du footer : incrémentation de la version affichée à `Version 2.14.99` dans `CartoModel.html`.

### Testing
- Vérification syntaxique JavaScript avec `node --check assets/js/rms.ui.js` qui a réussi.
- Vérification syntaxique JavaScript avec `node --check assets/js/rms.core.js` qui a réussi.
- Aucune erreur d'exécution statique rapportée après les modifications (basic smoke checks passés).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894a26564832e8fad6e625a89174d)