### PR TITLE
Fix Save instance detection; expose RMS aliases and bump version to 2.15.00

### DIFF
--- a/CartoModel.html
+++ b/CartoModel.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Corruption Risk Mapping - Sapin II v2.14.92</title>
+    <title>Corruption Risk Mapping - Sapin II v2.15.00</title>
     <link rel="stylesheet" href="assets/css/main.css">
     <!-- Local dependencies with CDN fallback -->
     <script>
@@ -884,7 +884,7 @@
             </div>
         </div>
         <footer class="app-footer">
-            <span class="app-version">Version 2.14.99</span>
+            <span class="app-version">Version 2.15.00</span>
         </footer>
     </div>
 

--- a/assets/js/rms.core.js
+++ b/assets/js/rms.core.js
@@ -11906,6 +11906,8 @@ var rms;
 function setRms(instance) {
     rms = instance;
     window.rms = instance;
+    window.RMS = instance;
+    window.RiskSystem = instance;
 }
 
 window.RiskManagementSystem = RiskManagementSystem;

--- a/assets/js/rms.integrations.js
+++ b/assets/js/rms.integrations.js
@@ -2092,7 +2092,8 @@ function importControlsCsv() {
 window.importControlsCsv = importControlsCsv;
 
 function exportOperationalData() {
-    if (!window.rms) {
+    const instance = window.rms || window.RMS || window.RiskSystem || (typeof rms !== 'undefined' ? rms : null);
+    if (!instance) {
         console.warn('RiskManagementSystem indisponible pour la sauvegarde.');
         if (typeof showNotification === 'function') {
             showNotification('error', "Save failed: instance not initialized");
@@ -2101,14 +2102,14 @@ function exportOperationalData() {
     }
 
     try {
-        if (typeof rms.saveData === 'function') {
-            rms.saveData();
+        if (typeof instance.saveData === 'function') {
+            instance.saveData();
         }
-        if (typeof rms.saveConfig === 'function') {
-            rms.saveConfig();
+        if (typeof instance.saveConfig === 'function') {
+            instance.saveConfig();
         }
 
-        const snapshot = rms.getSnapshot();
+        const snapshot = instance.getSnapshot();
         const payload = {
             risks: Array.isArray(snapshot.risks) ? snapshot.risks : [],
             controls: Array.isArray(snapshot.controls) ? snapshot.controls : [],

--- a/assets/js/rms.quick-assessment.js
+++ b/assets/js/rms.quick-assessment.js
@@ -76,7 +76,7 @@
     const state = {
         view: 'scenarios',
         data: {
-            version: '2.14.92',
+            version: '2.15.00',
             scenarios: [],
             selectedId: null
         }


### PR DESCRIPTION
### Motivation
- The top "Save" action could show "Save failed: instance not initialized" when the RiskManagementSystem instance existed under an alternate global name.
- Integrations and external scripts need consistent global aliases to reliably access the RMS instance and to keep UI versioning consistent.

### Description
- `exportOperationalData()` (in `assets/js/rms.integrations.js`) now resolves the RMS instance from `window.rms || window.RMS || window.RiskSystem || rms` and uses the resolved `instance` for save/export operations.
- `setRms(instance)` (in `assets/js/rms.core.js`) now exposes the instance on `window.RMS` and `window.RiskSystem` in addition to `window.rms`.
- Updated visible application version to `2.15.00` in `CartoModel.html` (title and footer) and synchronized the quick-assessment persisted `version` to `2.15.00` in `assets/js/rms.quick-assessment.js`.

### Testing
- Ran static syntax checks: `node --check assets/js/rms.core.js`, `node --check assets/js/rms.integrations.js`, and `node --check assets/js/rms.quick-assessment.js`, all succeeded.
- No browser or end-to-end tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e897037e30832ea1871350ba050b70)